### PR TITLE
feat: enable opencode.json standard plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,22 @@ Search through your OpenCode conversation history with keyword, regex, and fuzzy
 
 ## Installation
 
-### Quick Install (Recommended)
+### OpenCode Install (Recommended)
+
+Add to your OpenCode config (`~/.config/opencode/opencode.json`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "opencode-history-search"
+  ]
+}
+```
+
+Then restart OpenCode.
+
+### Quick Install
 
 ```bash
 # Using npx (npm)

--- a/dist/history-search.ts
+++ b/dist/history-search.ts
@@ -1,20 +1,4 @@
 // @bun
-var __create = Object.create;
-var __getProtoOf = Object.getPrototypeOf;
-var __defProp = Object.defineProperty;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __toESM = (mod, isNodeMode, target) => {
-  target = mod != null ? __create(__getProtoOf(mod)) : {};
-  const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
-  for (let key of __getOwnPropNames(mod))
-    if (!__hasOwnProp.call(to, key))
-      __defProp(to, key, {
-        get: () => mod[key],
-        enumerable: true
-      });
-  return to;
-};
 var __require = import.meta.require;
 
 // src/index.ts
@@ -1988,7 +1972,7 @@ function formatTraceResults(matches) {
   return lines.join(`
 `);
 }
-var src_default = tool({
+var historySearch = tool({
   description: `Search through past conversation histories in the current repository. 
 Searches session titles, message content, tool invocations, and file paths.
 Also supports tracing a specific file to see when it was first seen/touched and what user prompt triggered each touch.
@@ -2039,6 +2023,10 @@ Supports keyword search, regex patterns, fuzzy search (for typos and variations)
     return formatResults(matches);
   }
 });
+var server = async (_input, _options) => ({
+  tool: { "history-search": historySearch }
+});
+var src_default = { id: "opencode-history-search", server };
 export {
   src_default as default
 };

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "version": "1.2.0",
   "description": "Search OpenCode conversation history and trace which prompts touched specific files",
   "main": "dist/history-search.ts",
-  "module": "src/index.ts",
+  "module": "dist/history-search.ts",
   "type": "module",
+  "exports": {
+    ".": "./dist/history-search.ts"
+  },
   "bin": {
     "opencode-history-search": "./install.ts"
   },
@@ -43,6 +46,7 @@
   },
   "dependencies": {
     "@opencode-ai/plugin": "^1.1.48",
+    "bun": "^1.3.12",
     "fuse.js": "^7.1.0"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ Supports keyword search, regex patterns, fuzzy search (for typos and variations)
   },
 });
 
-const server = async (_input: unknown, _options?: unknown) => ({
+const server = async (_input?: unknown, _options?: unknown) => ({
   tool: { "history-search": historySearch },
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function formatTraceResults(matches: FileTraceResult[]): string {
   return lines.join("\n");
 }
 
-export default tool({
+const historySearch = tool({
   description: `Search through past conversation histories in the current repository. 
 Searches session titles, message content, tool invocations, and file paths.
 Also supports tracing a specific file to see when it was first seen/touched and what user prompt triggered each touch.
@@ -168,3 +168,9 @@ Supports keyword search, regex patterns, fuzzy search (for typos and variations)
     return formatResults(matches);
   },
 });
+
+const server = async (_input: unknown, _options?: unknown) => ({
+  tool: { "history-search": historySearch },
+});
+
+export default { id: "opencode-history-search", server };

--- a/test/date-filter-integration.test.ts
+++ b/test/date-filter-integration.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect } from "bun:test";
-import tool from "../src/index";
+import plugin from "../src/index";
 import type { ToolContext } from "@opencode-ai/plugin";
 
 const MAIN_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750";
+
+const tool = (await plugin.server(undefined)).tool["history-search"];
 
 const mockContext: ToolContext = {
   sessionID: "test-session",


### PR DESCRIPTION
I'm not totally sure this is right, but for me it works with:

```json
{
  "$schema": "https://opencode.ai/config.json",
  "plugin": [
    "github:emiasims/opencode-history-search#plugin-installable"
  ],
}
```
So if you merge and publish it I think it works? Specifically, just the "opencode-history-search" for the plugin config name. I don't know how any of that works, I know that you can specify repositories and branches via the syntax above, and it uses npm or bun to resolve the install names otherwise

Cool plugin!