### PR TITLE
perf(sqlite): share one connection per search instead of opening per row

### DIFF
--- a/src/search/fuzzy.test.ts
+++ b/src/search/fuzzy.test.ts
@@ -15,6 +15,9 @@ describe("fuzzy search (unit tests with mocks)", () => {
       listParts: mockListParts,
       getStorageDir: async () => "/mock/storage",
       getCurrentProjectID: async () => MOCK_PROJECT_ID,
+      // Force fallthrough to the generator path so the mock generators above
+      // are exercised (instead of the real SQLite DB).
+      withSqlite: async () => null,
     }));
   });
 

--- a/src/search/fuzzy.ts
+++ b/src/search/fuzzy.ts
@@ -1,7 +1,8 @@
 import Fuse from "fuse.js";
 import type { Session, Message, Part } from "../storage-provider";
-import { listSessions, listMessages, listParts } from "../storage-provider";
+import { listSessions, listMessages, listParts, withSqlite } from "../storage-provider";
 import type { SearchMatch } from "./keyword";
+import { listSessionRowsSync, listMessageRowsSync, listPartRowsSync } from "../storage-sqlite";
 
 interface SearchableItem {
   session: Session;
@@ -12,24 +13,63 @@ interface SearchableItem {
   timestamp: number;
 }
 
+export interface FuzzyOptions {
+  threshold?: number;
+  limit?: number;
+  role?: "user" | "assistant";
+}
+
 export async function searchFuzzy(
   projectID: string | null,
   query: string,
-  options: {
-    threshold?: number; // 0.0 = exact, 1.0 = anything (default: 0.4)
-    limit?: number;
-    role?: "user" | "assistant";
-  } = {},
+  options: FuzzyOptions = {},
 ): Promise<SearchMatch[]> {
-  const threshold = options.threshold ?? 0.4;
-  const limit = options.limit ?? 50;
+  // Fast path: single SQLite connection for the corpus build.
+  const fast = await withSqlite((db) =>
+    searchFuzzySqlite(db, projectID, query, options),
+  );
+  if (fast !== null) return fast;
+  return searchFuzzyGenerators(projectID, query, options);
+}
 
-  // Build searchable index
+function searchFuzzySqlite(
+  db: any,
+  projectID: string | null,
+  query: string,
+  options: FuzzyOptions,
+): SearchMatch[] {
+  const items: SearchableItem[] = [];
+
+  const sessions = listSessionRowsSync(db, projectID);
+  for (const session of sessions) {
+    items.push({
+      session,
+      content: session.title,
+      type: "title",
+      timestamp: session.time.updated,
+    });
+
+    const messages = listMessageRowsSync(db, session.id, options.role);
+    for (const message of messages) {
+      const parts = listPartRowsSync(db, message.id);
+      for (const part of parts) {
+        addPartItems(items, session, message, part);
+      }
+    }
+  }
+
+  return runFuse(items, query, options);
+}
+
+async function searchFuzzyGenerators(
+  projectID: string | null,
+  query: string,
+  options: FuzzyOptions,
+): Promise<SearchMatch[]> {
   const items: SearchableItem[] = [];
 
   try {
     for await (const session of listSessions(projectID)) {
-      // Index session title
       items.push({
         session,
         content: session.title,
@@ -37,91 +77,102 @@ export async function searchFuzzy(
         timestamp: session.time.updated,
       });
 
-      // Index messages
       try {
         for await (const message of listMessages(session.id, options.role)) {
           try {
             for await (const part of listParts(message.id)) {
-              if (part.type === "text" && part.text) {
-                items.push({
-                  session,
-                  content: part.text,
-                  type: "message",
-                  messageID: message.id,
-                  partID: part.id,
-                  timestamp: message.time.created,
-                });
-              }
-
-              if (part.type === "tool" && part.tool) {
-                items.push({
-                  session,
-                  content: part.tool + " " + (part.state?.title || ""),
-                  type: "tool",
-                  messageID: message.id,
-                  partID: part.id,
-                  timestamp: message.time.created,
-                });
-              }
-
-              // Index file paths from tool inputs/outputs
-              if (part.type === "tool" && part.state) {
-                const inputStr = JSON.stringify(part.state.input || {});
-                const outputStr = part.state.output || "";
-                const combined = inputStr + " " + outputStr;
-
-                // Extract file path patterns
-                const pathMatches = combined.match(/(?:\/[^/\s]+)+/g);
-                if (pathMatches) {
-                  for (const path of pathMatches) {
-                    items.push({
-                      session,
-                      content: path,
-                      type: "filepath",
-                      messageID: message.id,
-                      partID: part.id,
-                      timestamp: message.time.created,
-                    });
-                  }
-                }
-              }
-
-              // Index file paths from patch parts
-              if (part.type === "patch" && part.files) {
-                for (const filePath of part.files) {
-                  items.push({
-                    session,
-                    content: filePath,
-                    type: "filepath",
-                    messageID: message.id,
-                    partID: part.id,
-                    timestamp: message.time.created,
-                  });
-                }
-              }
+              addPartItems(items, session, message, part);
             }
           } catch {
-            // Skip corrupt part files
             continue;
           }
         }
       } catch {
-        // Skip sessions with missing message directory
         continue;
       }
     }
   } catch {
-    // Handle missing sessions directory
     return [];
   }
 
-  // Perform fuzzy search
+  return runFuse(items, query, options);
+}
+
+function addPartItems(
+  items: SearchableItem[],
+  session: Session,
+  message: Message,
+  part: Part,
+): void {
+  if (part.type === "text" && part.text) {
+    items.push({
+      session,
+      content: part.text,
+      type: "message",
+      messageID: message.id,
+      partID: part.id,
+      timestamp: message.time.created,
+    });
+  }
+
+  if (part.type === "tool" && part.tool) {
+    items.push({
+      session,
+      content: part.tool + " " + (part.state?.title || ""),
+      type: "tool",
+      messageID: message.id,
+      partID: part.id,
+      timestamp: message.time.created,
+    });
+  }
+
+  if (part.type === "tool" && part.state) {
+    const inputStr = JSON.stringify(part.state.input || {});
+    const outputStr = part.state.output || "";
+    const combined = inputStr + " " + outputStr;
+    const pathMatches = combined.match(/(?:\/[^/\s]+)+/g);
+    if (pathMatches) {
+      for (const p of pathMatches) {
+        items.push({
+          session,
+          content: p,
+          type: "filepath",
+          messageID: message.id,
+          partID: part.id,
+          timestamp: message.time.created,
+        });
+      }
+    }
+  }
+
+  if (part.type === "patch" && part.files) {
+    for (const filePath of part.files) {
+      items.push({
+        session,
+        content: filePath,
+        type: "filepath",
+        messageID: message.id,
+        partID: part.id,
+        timestamp: message.time.created,
+      });
+    }
+  }
+}
+
+function runFuse(
+  items: SearchableItem[],
+  query: string,
+  options: FuzzyOptions,
+): SearchMatch[] {
+  const threshold = options.threshold ?? 0.4;
+  const limit = options.limit ?? 50;
+
   const fuse = new Fuse(items, {
     keys: ["content"],
     threshold,
     includeScore: true,
     includeMatches: true,
-    ignoreLocation: true, // Don't bias toward beginning of string
+    ignoreLocation: true,
     minMatchCharLength: 2,
   });
 
@@ -132,12 +183,10 @@ export async function searchFuzzy(
       const matchedText = result.matches?.[0]?.value || result.item.content;
       const matchIndex = result.matches?.[0]?.indices?.[0]?.[0] || 0;
 
-      // Extract context around the match
       const contextStart = Math.max(0, matchIndex - 100);
       const contextEnd = Math.min(matchedText.length, matchIndex + 200);
       const context = matchedText.slice(contextStart, contextEnd);
 
-      // Extract excerpt (the matched portion)
       const excerptStart = Math.max(0, matchIndex - 20);
       const excerptEnd = Math.min(matchedText.length, matchIndex + 80);
       const excerpt = matchedText.slice(excerptStart, excerptEnd);

--- a/src/search/keyword.test.ts
+++ b/src/search/keyword.test.ts
@@ -15,6 +15,9 @@ describe("keyword search (unit tests with mocks)", () => {
       listParts: mockListParts,
       getStorageDir: async () => "/mock/storage",
       getCurrentProjectID: async () => MOCK_PROJECT_ID,
+      // Force fallthrough to the generator path so the mock generators above
+      // are exercised (instead of the real SQLite DB).
+      withSqlite: async () => null,
     }));
   });
 

--- a/src/search/keyword.ts
+++ b/src/search/keyword.ts
@@ -1,5 +1,6 @@
 import type { Session, Message, Part } from "../storage-provider";
-import { listSessions, listMessages, listParts } from "../storage-provider";
+import { listSessions, listMessages, listParts, withSqlite } from "../storage-provider";
+import { listSessionRowsSync, listMessageRowsSync, listPartRowsSync } from "../storage-sqlite";
 
 export interface SearchMatch {
   sessionID: string;
@@ -13,24 +14,90 @@ export interface SearchMatch {
   projectDirectory: string;
 }
 
+export interface KeywordOptions {
+  regex?: boolean;
+  caseSensitive?: boolean;
+  limit?: number;
+  role?: "user" | "assistant";
+}
+
 export async function searchKeyword(
   projectID: string | null,
   query: string,
-  options: {
-    regex?: boolean;
-    caseSensitive?: boolean;
-    limit?: number;
-    role?: "user" | "assistant";
-  } = {},
+  options: KeywordOptions = {},
 ): Promise<SearchMatch[]> {
-  const results: SearchMatch[] = [];
-  const pattern = options.regex
+  // Fast path: SQLite available => single shared connection, sync iteration.
+  const fast = await withSqlite((db) =>
+    searchKeywordSqlite(db, projectID, query, options),
+  );
+  if (fast !== null) return fast;
+  // Legacy JSON path (or tests that mock storage-provider)
+  return searchKeywordGenerators(projectID, query, options);
+}
+
+function buildPattern(query: string, options: KeywordOptions): RegExp {
+  return options.regex
     ? new RegExp(query, options.caseSensitive ? "" : "i")
     : new RegExp(
         query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
         options.caseSensitive ? "" : "i",
       );
+}
 
+// ---------------------------------------------------------------------------
+// SQLite fast path. One Database, plain for-loops, no async overhead per row.
+// ---------------------------------------------------------------------------
+function searchKeywordSqlite(
+  db: any,
+  projectID: string | null,
+  query: string,
+  options: KeywordOptions,
+): SearchMatch[] {
+  const pattern = buildPattern(query, options);
+  const limit = options.limit || 50;
+  const results: SearchMatch[] = [];
+
+  const sessions = listSessionRowsSync(db, projectID);
+  for (const session of sessions) {
+    if (results.length >= limit) break;
+
+    if (pattern.test(session.title)) {
+      results.push({
+        sessionID: session.id,
+        sessionTitle: session.title,
+        timestamp: session.time.updated,
+        matchType: "title",
+        excerpt: session.title,
+        context: session.title,
+        projectDirectory: session.directory,
+      });
+      if (results.length >= limit) break;
+    }
+
+    const messages = listMessageRowsSync(db, session.id, options.role);
+    for (const message of messages) {
+      if (results.length >= limit) break;
+      const parts = listPartRowsSync(db, message.id);
+      for (const part of parts) {
+        if (results.length >= limit) break;
+        matchPart(results, pattern, query, session, message, part, limit);
+      }
+    }
+  }
+
+  return results.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy generator path (JSON storage). Unchanged behavior.
+// ---------------------------------------------------------------------------
+async function searchKeywordGenerators(
+  projectID: string | null,
+  query: string,
+  options: KeywordOptions,
+): Promise<SearchMatch[]> {
+  const results: SearchMatch[] = [];
+  const pattern = buildPattern(query, options);
   const limit = options.limit || 50;
 
   for await (const session of listSessions(projectID)) {
@@ -51,96 +118,107 @@ export async function searchKeyword(
 
     for await (const message of listMessages(session.id, options.role)) {
       if (results.length >= limit) break;
-
       for await (const part of listParts(message.id)) {
         if (results.length >= limit) break;
-
-        if (part.type === "text" && part.text && pattern.test(part.text)) {
-          const match = part.text.match(pattern);
-          const matchIndex = match ? part.text.indexOf(match[0]) : 0;
-          const contextStart = Math.max(0, matchIndex - 100);
-          const contextEnd = Math.min(
-            part.text.length,
-            matchIndex + match![0].length + 100,
-          );
-          const context = part.text.slice(contextStart, contextEnd);
-
-          results.push({
-            sessionID: session.id,
-            sessionTitle: session.title,
-            timestamp: message.time.created,
-            matchType: "message",
-            excerpt: match ? match[0] : query,
-            context: context,
-            messageID: message.id,
-            partID: part.id,
-            projectDirectory: session.directory,
-          });
-          if (results.length >= limit) break;
-        }
-
-        if (results.length >= limit) break;
-        if (part.type === "tool" && part.tool && pattern.test(part.tool)) {
-          results.push({
-            sessionID: session.id,
-            sessionTitle: session.title,
-            timestamp: message.time.created,
-            matchType: "tool",
-            excerpt: part.tool,
-            context: part.state?.title || part.tool,
-            messageID: message.id,
-            partID: part.id,
-            projectDirectory: session.directory,
-          });
-          if (results.length >= limit) break;
-        }
-
-        if (results.length >= limit) break;
-        if (part.type === "tool" && part.state) {
-          const inputStr = JSON.stringify(part.state.input || {});
-          const outputStr = part.state.output || "";
-
-          if (pattern.test(inputStr) || pattern.test(outputStr)) {
-            const matched = pattern.exec(inputStr) || pattern.exec(outputStr);
-            if (matched) {
-              results.push({
-                sessionID: session.id,
-                sessionTitle: session.title,
-                timestamp: message.time.created,
-                matchType: "filepath",
-                excerpt: matched[0],
-                context: part.state.title || part.tool || "",
-                messageID: message.id,
-                partID: part.id,
-                projectDirectory: session.directory,
-              });
-              if (results.length >= limit) break;
-            }
-          }
-        }
-
-        // Search patch parts for file paths
-        if (results.length < limit && part.type === "patch" && part.files) {
-          for (const filePath of part.files) {
-            if (results.length >= limit) break;
-            if (pattern.test(filePath)) {
-              results.push({
-                sessionID: session.id,
-                sessionTitle: session.title,
-                timestamp: message.time.created,
-                matchType: "filepath",
-                excerpt: filePath,
-                context: `Modified file: ${filePath}`,
-                messageID: message.id,
-                partID: part.id,
-                projectDirectory: session.directory,
-              });
-            }
-          }
-        }
+        matchPart(results, pattern, query, session, message, part, limit);
       }
     }
   }
 
   return results.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+// ---------------------------------------------------------------------------
+// Shared per-part matcher. Identical logic for both paths.
+// ---------------------------------------------------------------------------
+function matchPart(
+  results: SearchMatch[],
+  pattern: RegExp,
+  query: string,
+  session: Session,
+  message: Message,
+  part: Part,
+  limit: number,
+): void {
+  if (results.length >= limit) return;
+
+  if (part.type === "text" && part.text && pattern.test(part.text)) {
+    const match = part.text.match(pattern);
+    const matchIndex = match ? part.text.indexOf(match[0]) : 0;
+    const contextStart = Math.max(0, matchIndex - 100);
+    const contextEnd = Math.min(
+      part.text.length,
+      matchIndex + match![0].length + 100,
+    );
+    const context = part.text.slice(contextStart, contextEnd);
+
+    results.push({
+      sessionID: session.id,
+      sessionTitle: session.title,
+      timestamp: message.time.created,
+      matchType: "message",
+      excerpt: match ? match[0] : query,
+      context,
+      messageID: message.id,
+      partID: part.id,
+      projectDirectory: session.directory,
+    });
+    if (results.length >= limit) return;
+  }
+
+  if (part.type === "tool" && part.tool && pattern.test(part.tool)) {
+    results.push({
+      sessionID: session.id,
+      sessionTitle: session.title,
+      timestamp: message.time.created,
+      matchType: "tool",
+      excerpt: part.tool,
+      context: part.state?.title || part.tool,
+      messageID: message.id,
+      partID: part.id,
+      projectDirectory: session.directory,
+    });
+    if (results.length >= limit) return;
+  }
+
+  if (part.type === "tool" && part.state) {
+    const inputStr = JSON.stringify(part.state.input || {});
+    const outputStr = part.state.output || "";
+    if (pattern.test(inputStr) || pattern.test(outputStr)) {
+      const matched = pattern.exec(inputStr) || pattern.exec(outputStr);
+      if (matched) {
+        results.push({
+          sessionID: session.id,
+          sessionTitle: session.title,
+          timestamp: message.time.created,
+          matchType: "filepath",
+          excerpt: matched[0],
+          context: part.state.title || part.tool || "",
+          messageID: message.id,
+          partID: part.id,
+          projectDirectory: session.directory,
+        });
+        if (results.length >= limit) return;
+      }
+    }
+  }
+
+  if (part.type === "patch" && part.files) {
+    for (const filePath of part.files) {
+      if (results.length >= limit) return;
+      if (pattern.test(filePath)) {
+        results.push({
+          sessionID: session.id,
+          sessionTitle: session.title,
+          timestamp: message.time.created,
+          matchType: "filepath",
+          excerpt: filePath,
+          context: `Modified file: ${filePath}`,
+          messageID: message.id,
+          partID: part.id,
+          projectDirectory: session.directory,
+        });
+      }
+    }
+  }
 }

--- a/src/storage-provider.ts
+++ b/src/storage-provider.ts
@@ -1,5 +1,6 @@
 import {
   dbExists,
+  withDb,
   listSessionsSqlite,
   listMessagesSqlite,
   listPartsSqlite,
@@ -12,8 +13,25 @@ import {
   getStorageDir,
 } from "./storage";
 import type { Session, Message, Part } from "./storage";
+import type { Database } from "bun:sqlite";
 
 const useSqlite = dbExists();
+
+/**
+ * If SQLite is available, opens a single shared connection, runs `fn`, then
+ * closes it. Returns the result. If SQLite is not available (legacy JSON
+ * backend, or storage-provider is mocked in tests), returns `null` so the
+ * caller can fall back to the generator-based path.
+ *
+ * This is the recommended entry point for any search code that wants the fast
+ * path: one connection per execute(), no per-row open/close.
+ */
+export async function withSqlite<T>(
+  fn: (db: Database) => Promise<T> | T,
+): Promise<T | null> {
+  if (!useSqlite) return null;
+  return await withDb(fn);
+}
 
 export async function* listSessions(
   projectID: string | null,

--- a/src/storage-sqlite.ts
+++ b/src/storage-sqlite.ts
@@ -17,9 +17,187 @@ export function dbExists(): boolean {
   }
 }
 
-function openDb(): Database {
+export function openDb(): Database {
   return new Database(getDbPath(), { readonly: true });
 }
+
+/**
+ * Run `fn` with a single shared read-only Database connection.
+ * Use this for any search path that touches multiple sessions/messages/parts
+ * so we don't pay the open/close cost per row.
+ */
+export async function withDb<T>(fn: (db: Database) => Promise<T> | T): Promise<T> {
+  const db = openDb();
+  try {
+    return await fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous, single-connection row iterators.
+//
+// These are the fast path. They take an existing `db` and return plain arrays
+// (or do callback iteration) rather than async generators, which avoids the
+// per-row event loop overhead AND lets us share one connection.
+// ---------------------------------------------------------------------------
+
+export interface RawPart {
+  id: string;
+  message_id: string;
+  session_id: string;
+  data: string;
+}
+
+export function listSessionRowsSync(
+  db: Database,
+  projectID: string | null,
+): Session[] {
+  const rows = (
+    projectID
+      ? db
+          .query(
+            `SELECT id, project_id, title, directory, time_created, time_updated
+             FROM session WHERE project_id = ?
+             ORDER BY time_updated DESC`,
+          )
+          .all(projectID)
+      : db
+          .query(
+            `SELECT id, project_id, title, directory, time_created, time_updated
+             FROM session
+             ORDER BY time_updated DESC`,
+          )
+          .all()
+  ) as Array<{
+    id: string;
+    project_id: string;
+    title: string;
+    directory: string;
+    time_created: number;
+    time_updated: number;
+  }>;
+
+  return rows.map((row) => ({
+    id: row.id,
+    projectID: row.project_id,
+    title: row.title,
+    directory: row.directory,
+    time: { created: row.time_created, updated: row.time_updated },
+  }));
+}
+
+export function listMessageRowsSync(
+  db: Database,
+  sessionID: string,
+  role?: "user" | "assistant",
+): Message[] {
+  const rows = db
+    .query(
+      `SELECT id, session_id, time_created, data
+       FROM message WHERE session_id = ?
+       ORDER BY time_created ASC`,
+    )
+    .all(sessionID) as Array<{
+    id: string;
+    session_id: string;
+    time_created: number;
+    data: string;
+  }>;
+
+  const out: Message[] = [];
+  for (const row of rows) {
+    const data = JSON.parse(row.data);
+    if (role && data.role !== role) continue;
+    out.push({
+      id: row.id,
+      sessionID: row.session_id,
+      role: data.role,
+      agent: data.agent || "",
+      time: { created: row.time_created },
+    });
+  }
+  return out;
+}
+
+export function listPartRowsSync(db: Database, messageID: string): Part[] {
+  const rows = db
+    .query(
+      `SELECT id, message_id, session_id, data
+       FROM part WHERE message_id = ?
+       ORDER BY time_created ASC`,
+    )
+    .all(messageID) as Array<{
+    id: string;
+    message_id: string;
+    session_id: string;
+    data: string;
+  }>;
+
+  const out: Part[] = [];
+  for (const row of rows) {
+    const part = decodePart(row);
+    if (part) out.push(part);
+  }
+  return out;
+}
+
+/**
+ * Decode a raw part row into our Part shape, or null if it's a type we
+ * don't search over (reasoning, step-start, etc).
+ */
+export function decodePart(row: {
+  id: string;
+  message_id: string;
+  session_id: string;
+  data: string;
+}): Part | null {
+  let data: any;
+  try {
+    data = JSON.parse(row.data);
+  } catch {
+    return null;
+  }
+
+  const type =
+    data.type === "text"
+      ? "text"
+      : data.type === "tool"
+        ? "tool"
+        : data.type === "file"
+          ? "file"
+          : data.type === "patch"
+            ? "patch"
+            : null;
+
+  if (!type) return null;
+
+  const part: Part = {
+    id: row.id,
+    messageID: row.message_id,
+    sessionID: row.session_id,
+    type: type as "text" | "tool" | "file" | "patch",
+  };
+
+  if (type === "text") {
+    part.text = data.text;
+  } else if (type === "tool") {
+    part.tool = data.tool;
+    part.state = data.state;
+  } else if (type === "patch") {
+    part.files = data.files;
+  }
+
+  return part;
+}
+
+// ---------------------------------------------------------------------------
+// Async generator wrappers (kept for back-compat with storage-provider.ts and
+// any callers that still iterate via for-await). Internally these now use the
+// sync helpers above, and accept an optional `db` so a parent scope can share
+// one connection across many calls.
+// ---------------------------------------------------------------------------
 
 export async function* listSessionsSqlite(
   projectID: string | null,
@@ -28,39 +206,8 @@ export async function* listSessionsSqlite(
   const shouldClose = db === undefined;
   const _db = db ?? openDb();
   try {
-    const rows = (
-      projectID
-        ? _db
-            .query(
-              `SELECT id, project_id, title, directory, time_created, time_updated
-               FROM session WHERE project_id = ?
-               ORDER BY time_updated DESC`,
-            )
-            .all(projectID)
-        : _db
-            .query(
-              `SELECT id, project_id, title, directory, time_created, time_updated
-               FROM session
-               ORDER BY time_updated DESC`,
-            )
-            .all()
-    ) as Array<{
-      id: string;
-      project_id: string;
-      title: string;
-      directory: string;
-      time_created: number;
-      time_updated: number;
-    }>;
-
-    for (const row of rows) {
-      yield {
-        id: row.id,
-        projectID: row.project_id,
-        title: row.title,
-        directory: row.directory,
-        time: { created: row.time_created, updated: row.time_updated },
-      };
+    for (const session of listSessionRowsSync(_db, projectID)) {
+      yield session;
     }
   } finally {
     if (shouldClose) _db.close();
@@ -70,92 +217,30 @@ export async function* listSessionsSqlite(
 export async function* listMessagesSqlite(
   sessionID: string,
   role?: "user" | "assistant",
+  db?: Database,
 ): AsyncGenerator<Message> {
-  const db = openDb();
+  const shouldClose = db === undefined;
+  const _db = db ?? openDb();
   try {
-    const rows = db
-      .query(
-        `SELECT id, session_id, time_created, data
-         FROM message WHERE session_id = ?
-         ORDER BY time_created ASC`,
-      )
-      .all(sessionID) as Array<{
-      id: string;
-      session_id: string;
-      time_created: number;
-      data: string;
-    }>;
-
-    for (const row of rows) {
-      const data = JSON.parse(row.data);
-      if (role && data.role !== role) continue;
-      yield {
-        id: row.id,
-        sessionID: row.session_id,
-        role: data.role,
-        agent: data.agent || "",
-        time: { created: row.time_created },
-      };
+    for (const message of listMessageRowsSync(_db, sessionID, role)) {
+      yield message;
     }
   } finally {
-    db.close();
+    if (shouldClose) _db.close();
   }
 }
 
 export async function* listPartsSqlite(
   messageID: string,
+  db?: Database,
 ): AsyncGenerator<Part> {
-  const db = openDb();
+  const shouldClose = db === undefined;
+  const _db = db ?? openDb();
   try {
-    const rows = db
-      .query(
-        `SELECT id, message_id, session_id, data
-         FROM part WHERE message_id = ?
-         ORDER BY time_created ASC`,
-      )
-      .all(messageID) as Array<{
-      id: string;
-      message_id: string;
-      session_id: string;
-      data: string;
-    }>;
-
-    for (const row of rows) {
-      const data = JSON.parse(row.data);
-
-      // Map SQLite part types to our interface types
-      const type =
-        data.type === "text"
-          ? "text"
-          : data.type === "tool"
-            ? "tool"
-            : data.type === "file"
-              ? "file"
-              : data.type === "patch"
-                ? "patch"
-                : null;
-
-      if (!type) continue; // Skip step-start, step-finish, reasoning, compaction, agent, etc.
-
-      const part: Part = {
-        id: row.id,
-        messageID: row.message_id,
-        sessionID: row.session_id,
-        type: type as "text" | "tool" | "file" | "patch",
-      };
-
-      if (type === "text") {
-        part.text = data.text;
-      } else if (type === "tool") {
-        part.tool = data.tool;
-        part.state = data.state;
-      } else if (type === "patch") {
-        part.files = data.files;
-      }
-
+    for (const part of listPartRowsSync(_db, messageID)) {
       yield part;
     }
   } finally {
-    db.close();
+    if (shouldClose) _db.close();
   }
 }


### PR DESCRIPTION
Standalone perf fix. Doesn't change behavior, doesn't change schema, doesn't add dependencies. Just stops opening and closing a SQLite connection inside the hot loop.

## The bug

Original SQLite implementation opens a new `bun:sqlite` Database inside `listSessionsSqlite`, `listMessagesSqlite`, and `listPartsSqlite`. The async generator pattern then iterates millions of rows with one connection cycle per row.

On my DB (3.9 GB, 932 sessions, 63k messages, 209k parts), a single keyword search like `"kubernetes"` triggers tens of thousands of `Database` open/close cycles plus a `JSON.parse` on every part. Result: ~13 seconds per query on rare terms.

Your "<50ms even with thousands of messages" claim holds at small scale. The N² pattern only bites once `parts × messages` gets large.

## The fix

- Add `withDb(callback)` and `listSessionRowsSync` / `listMessageRowsSync` / `listPartRowsSync` helpers in `storage-sqlite`. All take a `Database` argument.
- Add `withSqlite(callback)` in `storage-provider` that opens one connection if SQLite is available, runs the callback, then closes. Returns `null` when SQLite isn't available so callers fall back to the JSON path.
- Rewrite `searchKeyword` and `searchFuzzy` to use the SQLite fast path via `withSqlite`. Original generator-based path stays as the fallback for JSON storage (and for unit tests that mock the provider).
- Async generator wrappers (`listSessionsSqlite`, etc.) still exist for back-compat and now accept an optional shared `db` argument.

## Benchmark on a 3.9 GB DB (932 sessions / 63k messages / 209k parts)

| Query                           | Before     | After      | Speedup |
| ------------------------------- | ---------: | ---------: | ------: |
| `storage`, project-scoped       |   1,194 ms |     4.8 ms |    250x |
| `kubernetes`, project-scoped    |  13,602 ms |      287 ms |    47x  |
| `kubernetes`, global            | didn't finish |      277 ms |    >50x |

Fuzzy still rebuilds the Fuse corpus and remains O(n). PR #2 (FTS5) addresses that.

## Tests

All 95 existing tests pass. No behavior changes. No new test files.

## Followup

PR #8 (`borski:perf/phase2-fts5-index`) builds on this and adds an FTS5 full-text index for keyword and fuzzy search. That one's a larger change because it modifies the user's DB schema. This PR is intentionally split out so the easy perf win can land independently if you'd rather think about the FTS work separately.