### PR TITLE
perf(search): FTS5 full-text + trigram indexes for keyword and fuzzy search

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,22 @@ Uses regular expressions for pattern matching.
 
 ### Fuzzy Search
 
-Tolerates typos and variations using Levenshtein distance.
+Tolerates typos and substrings. On SQLite (v1.2+) this uses an FTS5 trigram
+index, so it stays fast as your history grows. The legacy JSON backend uses
+Fuse.js Levenshtein matching.
 
 ```typescript
-{ query: "storag", mode: "fuzzy", fuzzyThreshold: 0.3 }
+{ query: "storag", mode: "fuzzy" }
 // Finds: "storage" (missing letter)
 
-{ query: "ripgrap", mode: "fuzzy", fuzzyThreshold: 0.4 }
-// Finds: "ripgrep" (transposition)
+{ query: "authent", mode: "fuzzy" }
+// Finds: "authentication" (substring)
 ```
+
+Trigram matching catches most typos and partial words. It's stricter than
+Levenshtein on transpositions (e.g. `"ripgrap"` won't always reach
+`"ripgrep"`). When in doubt, try keyword search first; it's faster and more
+predictable.
 
 ## Date Filtering
 
@@ -235,22 +242,25 @@ Real-world benchmark against a 3.9 GB OpenCode DB (932 sessions, 63,640 messages
 | `the` (worst-case common)    |          378ms |   360ms |
 | `the` + `last 7 days` filter |              — |   273ms |
 | `the` + `role=user` filter   |              — |    76ms |
+| `storag` fuzzy (typo)        |           30ms |    29ms |
+| `authent` fuzzy (substring)  |           39ms |    38ms |
 
-For comparison, the same queries before the FTS5 index took 1-13+ seconds. The biggest wins are on rare-term and global searches, which previously had to scan every part row in the DB.
+For comparison, the same queries before the FTS5 index took 1-13+ seconds for keyword search and 15+ seconds for fuzzy. The biggest wins are on rare-term, fuzzy, and global searches, which previously had to scan every part row in the DB.
 
 ## FTS5 Index
 
 When the plugin first runs against a SQLite DB, it adds the following to OpenCode's `opencode.db`:
 
-- **`part_fts`** — FTS5 virtual table (plus its FTS5 shadow tables: `part_fts_data`, `part_fts_idx`, `part_fts_content`, `part_fts_docsize`, `part_fts_config`). One row per searchable piece of part content: message text, tool name + title, tool input/output blob, and one row per file path in a patch.
+- **`part_fts`** — FTS5 virtual table with the default `unicode61` tokenizer (plus its FTS5 shadow tables: `part_fts_data`, `part_fts_idx`, `part_fts_content`, `part_fts_docsize`, `part_fts_config`). Powers keyword search. One row per searchable piece of part content: message text, tool name + title, tool input/output blob, and one row per file path in a patch.
+- **`part_fts_tri`** — FTS5 virtual table with the `trigram` tokenizer (plus shadow tables). Powers fuzzy and substring search. Indexes only `text` and `tool_name` kinds (tool_state and patch_file aren't useful for fuzzy matching).
 - **`part_fts_meta`** — A two-row table tracking the FTS schema version and the highest indexed `part.rowid`. Used to detect when an incremental backfill is needed.
-- **Three `AFTER` triggers on `part`** (`part_fts_ai`, `part_fts_au`, `part_fts_ad`) that mirror inserts, updates, and deletes into `part_fts`.
+- **Three `AFTER` triggers on `part`** (`part_fts_ai`, `part_fts_au`, `part_fts_ad`) that mirror inserts, updates, and deletes into both FTS tables.
 
 **The plugin never reads or writes rows in OpenCode-owned tables.** It only adds the auxiliary tables and triggers above.
 
-**Storage overhead:** roughly 1-2% of total DB size. On a 3.9 GB DB, the index plus shadow tables consume about 55 MB. The index grows proportionally to OpenCode's message volume.
+**Storage overhead:** roughly 12-15% of total DB size on a typical install (the unicode61 index is ~10%, the trigram index adds another ~3%). On a 3.9 GB DB, the combined indexes plus shadow tables consume about 550 MB. The index grows proportionally to OpenCode's message volume.
 
-**Index build:** On first run the plugin builds the index in a single transaction. On a 200k-part DB this takes about 3 seconds with no concurrent writers, up to ~17 seconds if OpenCode is actively writing to the DB at the same time. The log message `[history-search] Built FTS5 search index in Nms (one-time setup, see README "Rollback" to remove).` confirms when this happens.
+**Index build:** On first run the plugin builds both indexes in a single transaction. On a 200k-part DB this takes about 10-15 seconds with no concurrent writers, up to ~30 seconds if OpenCode is actively writing to the DB at the same time. The log message `[history-search] Built FTS5 search index in Nms (one-time setup, see README "Rollback" to remove).` confirms when this happens.
 
 **Schema drift defense:** On every search the plugin samples the most recent text, tool, and patch row from `part` and verifies the JSON keys it depends on (`$.text`, `$.tool`, `$.files`) still exist. If OpenCode ever renames these keys in a future release, the plugin logs a warning and forces a rebuild. The rebuild itself won't fix the drift — you'd need a plugin update — but you'll see the warning instead of silently degraded search.
 
@@ -270,12 +280,13 @@ BEGIN IMMEDIATE;
   DROP TRIGGER IF EXISTS part_fts_ai;
   DROP TRIGGER IF EXISTS part_fts_au;
   DROP TRIGGER IF EXISTS part_fts_ad;
-  -- Drop the virtual table (cascades the FTS5 shadow tables).
+  -- Drop the virtual tables (cascades the FTS5 shadow tables).
   DROP TABLE IF EXISTS part_fts;
+  DROP TABLE IF EXISTS part_fts_tri;
   DROP TABLE IF EXISTS part_fts_meta;
 COMMIT;
 
--- Optional: reclaim ~55 MB on a 3.9 GB DB. Slow (single-threaded,
+-- Optional: reclaim ~550 MB on a 3.9 GB DB. Slow (single-threaded,
 -- rewrites the entire DB) and takes an EXCLUSIVE lock. Only run
 -- while OpenCode is stopped.
 -- VACUUM;
@@ -288,10 +299,10 @@ OpenCode never sees that the plugin was there.
 After the plugin has run at least once, you can confirm the index is healthy with:
 
 ```sql
--- 1) FTS table and meta table both exist
+-- 1) Both FTS tables and meta table exist
 SELECT name FROM sqlite_master
-WHERE type='table' AND name IN ('part_fts','part_fts_meta');
--- expect: part_fts, part_fts_meta
+WHERE type='table' AND name IN ('part_fts','part_fts_tri','part_fts_meta');
+-- expect: part_fts, part_fts_meta, part_fts_tri
 
 -- 2) All three triggers installed
 SELECT name FROM sqlite_master
@@ -309,11 +320,13 @@ SELECT
   (SELECT value FROM part_fts_meta WHERE key='last_rowid') AS watermark,
   (SELECT MAX(rowid)              FROM part)               AS max_rowid;
 
--- 5) FTS5 internal integrity check (no output = healthy).
+-- 5) FTS5 internal integrity check on both indexes (no output = healthy).
 INSERT INTO part_fts(part_fts) VALUES('integrity-check');
+INSERT INTO part_fts_tri(part_fts_tri) VALUES('integrity-check');
 
--- 6) Quick functional smoke test.
-SELECT COUNT(*) FROM part_fts WHERE content MATCH '"the"';
+-- 6) Quick functional smoke tests (keyword + fuzzy substring).
+SELECT COUNT(*) FROM part_fts     WHERE content MATCH '"the"';
+SELECT COUNT(*) FROM part_fts_tri WHERE content MATCH '"the"';
 ```
 
 ## Storage Structure

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Search through your OpenCode conversation history across ALL projects or within 
 - **Multiple Match Types** - Search across session titles, messages, tool invocations, and file paths
 - **Global Search** - Search across ALL projects on your machine with `searchAllProjects: true`
 - **Project-Aware Results** - See which project directory each result came from
-- **Fast** - Queries complete in < 50ms even with thousands of messages
+- **Fast** - SQLite FTS5 full-text index. Sub-50ms on small histories, sub-100ms on most queries even at hundreds of thousands of parts. See [Performance](#performance) for benchmark details.
 - **SQLite + JSON Support** - Works with OpenCode v1.2+ (SQLite) and v1.1.x (JSON files)
 
 ## Installation
@@ -134,7 +134,7 @@ Things you can ask OpenCode once this tool is installed:
 | `mode`           | `"keyword"` \| `"fuzzy"`  | `"keyword"` | Search mode                                            |
 | `regex`          | boolean                   | `false`     | Treat query as regex (keyword mode only)               |
 | `caseSensitive`  | boolean                   | `false`     | Enable case-sensitive search (keyword mode only)       |
-| `fuzzyThreshold` | number                    | `0.4`       | Fuzzy match strictness 0.0-1.0 (fuzzy mode only)       |
+| `fuzzyThreshold` | number                    | `0.4`       | Fuzzy match strictness 0.0-1.0. Only applies to the JSON-storage backend (Fuse.js). Ignored on SQLite, which uses an FTS5 trigram index with its own match semantics. |
 | `date`           | string                    | _none_      | Filter by date (see [Date Filtering](#date-filtering)) |
 | `limit`          | number                    | `50`        | Maximum number of results                              |
 | `role`           | `"user"` \| `"assistant"` | _none_      | Filter by message role (omit to search both)           |
@@ -207,20 +207,114 @@ Found 3 matches in conversation history:
 
 ### Match Types
 
-| Type        | What it matches                                           |
-| ----------- | --------------------------------------------------------- |
-| `title`     | Session title                                             |
-| `message`   | Text content of a user or assistant message               |
-| `tool`      | Tool name (grep, edit, bash, read, etc.)                  |
-| `filepath`  | File paths in tool inputs/outputs or patch parts          |
+| Type        | What it matches                                                            |
+| ----------- | -------------------------------------------------------------------------- |
+| `title`     | Session title                                                              |
+| `message`   | Text content of a user or assistant message                                |
+| `tool`      | Tool name, title, or content of the tool's input/output (e.g. arguments)   |
+| `filepath`  | File paths in patch parts (`write`/`edit` operations)                      |
 
 ## How It Works
 
-1. **Storage**: Auto-detects SQLite (v1.2+) or JSON files (v1.1.x) — SQLite preferred when present
+1. **Storage**: Auto-detects SQLite (v1.2+) or JSON files (v1.1.x). SQLite is preferred when present.
 2. **Project Scoping**: By default, scopes searches to current repository via git root commit hash. Set `searchAllProjects: true` to search across all projects.
-3. **Indexing**: For fuzzy search, builds a searchable index of all content
-4. **Matching**: Applies chosen search algorithm (keyword, regex, or fuzzy)
-5. **Sorting**: Returns results sorted by timestamp (newest first)
+3. **Indexing**: On first run against a SQLite DB, the plugin builds an FTS5 full-text index over part content (text, tool names + state, patch file paths). Triggers keep the index in sync as OpenCode writes new messages. See [FTS5 Index](#fts5-index) below.
+4. **Matching**: Applies chosen search algorithm. Keyword and fuzzy modes use the FTS5 index. Regex mode falls back to a row scan.
+5. **Sorting**: Returns results sorted by timestamp (newest first).
+
+## Performance
+
+Real-world benchmark against a 3.9 GB OpenCode DB (932 sessions, 63,640 messages, 209,505 parts):
+
+| Query                        | Project-scoped | Global  |
+| ---------------------------- | -------------: | ------: |
+| `storage` (common term)      |           60ms |    60ms |
+| `kubernetes` (rare term)     |           29ms |    29ms |
+| `webhook` (rare term)        |           39ms |    38ms |
+| `authentication`             |           39ms |    43ms |
+| `the` (worst-case common)    |          378ms |   360ms |
+| `the` + `last 7 days` filter |              — |   273ms |
+| `the` + `role=user` filter   |              — |    76ms |
+
+For comparison, the same queries before the FTS5 index took 1-13+ seconds. The biggest wins are on rare-term and global searches, which previously had to scan every part row in the DB.
+
+## FTS5 Index
+
+When the plugin first runs against a SQLite DB, it adds the following to OpenCode's `opencode.db`:
+
+- **`part_fts`** — FTS5 virtual table (plus its FTS5 shadow tables: `part_fts_data`, `part_fts_idx`, `part_fts_content`, `part_fts_docsize`, `part_fts_config`). One row per searchable piece of part content: message text, tool name + title, tool input/output blob, and one row per file path in a patch.
+- **`part_fts_meta`** — A two-row table tracking the FTS schema version and the highest indexed `part.rowid`. Used to detect when an incremental backfill is needed.
+- **Three `AFTER` triggers on `part`** (`part_fts_ai`, `part_fts_au`, `part_fts_ad`) that mirror inserts, updates, and deletes into `part_fts`.
+
+**The plugin never reads or writes rows in OpenCode-owned tables.** It only adds the auxiliary tables and triggers above.
+
+**Storage overhead:** roughly 1-2% of total DB size. On a 3.9 GB DB, the index plus shadow tables consume about 55 MB. The index grows proportionally to OpenCode's message volume.
+
+**Index build:** On first run the plugin builds the index in a single transaction. On a 200k-part DB this takes about 3 seconds with no concurrent writers, up to ~17 seconds if OpenCode is actively writing to the DB at the same time. The log message `[history-search] Built FTS5 search index in Nms (one-time setup, see README "Rollback" to remove).` confirms when this happens.
+
+**Schema drift defense:** On every search the plugin samples the most recent text, tool, and patch row from `part` and verifies the JSON keys it depends on (`$.text`, `$.tool`, `$.files`) still exist. If OpenCode ever renames these keys in a future release, the plugin logs a warning and forces a rebuild. The rebuild itself won't fix the drift — you'd need a plugin update — but you'll see the warning instead of silently degraded search.
+
+**Trigger safety:** The triggers cannot abort an OpenCode write. Every `json_extract` is guarded by `json_valid(NEW.data)`, and the `json_each` over `$.files` is wrapped in a `CASE WHEN json_type(...,'$.files')='array'` check. A future OpenCode bug that writes non-JSON or non-array data to `part.data` will be silently skipped by the trigger instead of crashing the host INSERT. Verified by tests.
+
+### Rollback
+
+If you uninstall the plugin and want to remove the FTS index and triggers:
+
+```sql
+-- Safe to run while OpenCode is running.
+-- BEGIN IMMEDIATE waits politely for any in-flight writer.
+PRAGMA busy_timeout = 15000;
+BEGIN IMMEDIATE;
+  -- Drop triggers FIRST so no in-flight INSERT/UPDATE/DELETE
+  -- writes to a table that's about to disappear.
+  DROP TRIGGER IF EXISTS part_fts_ai;
+  DROP TRIGGER IF EXISTS part_fts_au;
+  DROP TRIGGER IF EXISTS part_fts_ad;
+  -- Drop the virtual table (cascades the FTS5 shadow tables).
+  DROP TABLE IF EXISTS part_fts;
+  DROP TABLE IF EXISTS part_fts_meta;
+COMMIT;
+
+-- Optional: reclaim ~55 MB on a 3.9 GB DB. Slow (single-threaded,
+-- rewrites the entire DB) and takes an EXCLUSIVE lock. Only run
+-- while OpenCode is stopped.
+-- VACUUM;
+```
+
+OpenCode never sees that the plugin was there.
+
+### Verification
+
+After the plugin has run at least once, you can confirm the index is healthy with:
+
+```sql
+-- 1) FTS table and meta table both exist
+SELECT name FROM sqlite_master
+WHERE type='table' AND name IN ('part_fts','part_fts_meta');
+-- expect: part_fts, part_fts_meta
+
+-- 2) All three triggers installed
+SELECT name FROM sqlite_master
+WHERE type='trigger' AND name LIKE 'part_fts_%'
+ORDER BY name;
+-- expect: part_fts_ad, part_fts_ai, part_fts_au
+
+-- 3) Schema version and watermark
+SELECT key, value FROM part_fts_meta;
+-- expect a `version` row and a `last_rowid` row
+
+-- 4) Index covers most of `part`. The watermark vs MAX(rowid)
+--    gap will close on the next ensureFts() call.
+SELECT
+  (SELECT value FROM part_fts_meta WHERE key='last_rowid') AS watermark,
+  (SELECT MAX(rowid)              FROM part)               AS max_rowid;
+
+-- 5) FTS5 internal integrity check (no output = healthy).
+INSERT INTO part_fts(part_fts) VALUES('integrity-check');
+
+-- 6) Quick functional smoke test.
+SELECT COUNT(*) FROM part_fts WHERE content MATCH '"the"';
+```
 
 ## Storage Structure
 
@@ -261,11 +355,13 @@ src/
 ├── index.ts                  # Tool definition & main entry
 ├── format.ts                 # Output formatting
 ├── storage.ts                # JSON storage backend (v1.1.x)
-├── storage-sqlite.ts         # SQLite storage backend (v1.2+)
-├── storage-provider.ts       # Auto-detects backend, unified API
+├── storage-sqlite.ts         # SQLite storage backend (v1.2+) + shared sync helpers
+├── storage-provider.ts       # Auto-detects backend, unified API, ensureFtsOnce()
 └── search/
-    ├── keyword.ts            # Keyword & regex search
+    ├── fts.ts                # FTS5 index, triggers, watermark, drift defense
+    ├── keyword.ts            # Keyword & regex search (uses FTS5 when available)
     ├── fuzzy.ts              # Fuzzy search
+    ├── file-trace.ts         # File modification tracking
     └── date-filter.ts        # Date filtering
 ```
 
@@ -276,5 +372,6 @@ MIT
 ## Acknowledgments
 
 - Built for [OpenCode](https://opencode.ai)
-- Uses [Fuse.js](https://fusejs.io/) for fuzzy search
+- Uses SQLite [FTS5](https://www.sqlite.org/fts5.html) (unicode61 + trigram tokenizers) for keyword and fuzzy search on SQLite-backed installs
+- Uses [Fuse.js](https://fusejs.io/) for fuzzy search on the legacy JSON storage backend
 - Powered by [Bun](https://bun.sh)

--- a/dist/history-search.ts
+++ b/dist/history-search.ts
@@ -13,89 +13,130 @@ function getDbPath() {
   return path.join(xdgData, "opencode", "opencode.db");
 }
 function dbExists() {
-  try {
-    return Bun.file(getDbPath()).size > 0;
-  } catch {
-    return false;
-  }
+  return Bun.file(getDbPath()).size > 0;
 }
 function openDb() {
   return new Database(getDbPath(), { readonly: true });
+}
+async function withDb(fn) {
+  const db = openDb();
+  try {
+    return await fn(db);
+  } finally {
+    db.close();
+  }
+}
+function listSessionRowsSync(db, projectID) {
+  const rows = projectID ? db.query(`SELECT id, project_id, title, directory, time_created, time_updated
+             FROM session WHERE project_id = ?
+             ORDER BY time_updated DESC`).all(projectID) : db.query(`SELECT id, project_id, title, directory, time_created, time_updated
+             FROM session
+             ORDER BY time_updated DESC`).all();
+  return rows.map((row) => ({
+    id: row.id,
+    projectID: row.project_id,
+    title: row.title,
+    directory: row.directory,
+    time: { created: row.time_created, updated: row.time_updated }
+  }));
+}
+function listMessageRowsSync(db, sessionID, role) {
+  const rows = db.query(`SELECT id, session_id, time_created, data
+       FROM message WHERE session_id = ?
+       ORDER BY time_created ASC`).all(sessionID);
+  const out = [];
+  for (const row of rows) {
+    const data = JSON.parse(row.data);
+    if (role && data.role !== role)
+      continue;
+    out.push({
+      id: row.id,
+      sessionID: row.session_id,
+      role: data.role,
+      agent: data.agent || "",
+      time: { created: row.time_created }
+    });
+  }
+  return out;
+}
+function listPartRowsSync(db, messageID) {
+  const rows = db.query(`SELECT id, message_id, session_id, data
+       FROM part WHERE message_id = ?
+       ORDER BY time_created ASC`).all(messageID);
+  const out = [];
+  for (const row of rows) {
+    const part = decodePart(row);
+    if (part)
+      out.push(part);
+  }
+  return out;
+}
+function isSearchableType(t) {
+  return t === "text" || t === "tool" || t === "file" || t === "patch";
+}
+function decodePart(row) {
+  let parsed;
+  try {
+    parsed = JSON.parse(row.data);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null)
+    return null;
+  const raw = parsed;
+  if (!isSearchableType(raw.type))
+    return null;
+  const data = raw;
+  const part = {
+    id: row.id,
+    messageID: row.message_id,
+    sessionID: row.session_id,
+    type: data.type
+  };
+  if (data.type === "text") {
+    part.text = data.text;
+  } else if (data.type === "tool") {
+    part.tool = data.tool;
+    part.state = data.state;
+  } else if (data.type === "patch") {
+    part.files = data.files;
+  }
+  return part;
 }
 async function* listSessionsSqlite(projectID, db) {
   const shouldClose = db === undefined;
   const _db = db ?? openDb();
   try {
-    const rows = projectID ? _db.query(`SELECT id, project_id, title, directory, time_created, time_updated
-               FROM session WHERE project_id = ?
-               ORDER BY time_updated DESC`).all(projectID) : _db.query(`SELECT id, project_id, title, directory, time_created, time_updated
-               FROM session
-               ORDER BY time_updated DESC`).all();
-    for (const row of rows) {
-      yield {
-        id: row.id,
-        projectID: row.project_id,
-        title: row.title,
-        directory: row.directory,
-        time: { created: row.time_created, updated: row.time_updated }
-      };
+    for (const session of listSessionRowsSync(_db, projectID)) {
+      yield session;
     }
   } finally {
     if (shouldClose)
       _db.close();
   }
 }
-async function* listMessagesSqlite(sessionID, role) {
-  const db = openDb();
+async function* listMessagesSqlite(sessionID, role, db) {
+  const shouldClose = db === undefined;
+  const _db = db ?? openDb();
   try {
-    const rows = db.query(`SELECT id, session_id, time_created, data
-         FROM message WHERE session_id = ?
-         ORDER BY time_created ASC`).all(sessionID);
-    for (const row of rows) {
-      const data = JSON.parse(row.data);
-      if (role && data.role !== role)
-        continue;
-      yield {
-        id: row.id,
-        sessionID: row.session_id,
-        role: data.role,
-        agent: data.agent || "",
-        time: { created: row.time_created }
-      };
+    for (const message of listMessageRowsSync(_db, sessionID, role)) {
+      yield message;
     }
   } finally {
-    db.close();
+    if (shouldClose)
+      _db.close();
   }
 }
-async function* listPartsSqlite(messageID) {
-  const db = openDb();
+async function* listPartsSqlite(messageID, db) {
+  const shouldClose = db === undefined;
+  const _db = db ?? openDb();
   try {
-    const rows = db.query(`SELECT id, message_id, session_id, data
-         FROM part WHERE message_id = ?
-         ORDER BY time_created ASC`).all(messageID);
-    for (const row of rows) {
-      const data = JSON.parse(row.data);
-      const type = data.type === "text" ? "text" : data.type === "tool" ? "tool" : data.type === "file" ? "file" : data.type === "patch" ? "patch" : null;
-      if (!type)
-        continue;
-      const part = {
-        id: row.id,
-        messageID: row.message_id,
-        sessionID: row.session_id,
-        type
-      };
-      if (type === "text") {
-        part.text = data.text;
-      } else if (type === "tool") {
-        part.tool = data.tool;
-        part.state = data.state;
-      } else if (type === "patch") {
-        part.files = data.files;
-      }
+    for (const part of listPartRowsSync(_db, messageID)) {
       yield part;
     }
   } finally {
-    db.close();
+    if (shouldClose)
+      _db.close();
   }
 }
 
@@ -202,24 +243,448 @@ async function* listParts(messageID) {
   }
 }
 
+// src/search/fts.ts
+import { Database as Database2 } from "bun:sqlite";
+var FTS_TABLE = "part_fts";
+var TRI_TABLE = "part_fts_tri";
+var FTS_VERSION = 5;
+var BUSY_TIMEOUT_MS = 15000;
+var TRANSIENT_RETRY_MS = 60000;
+var ensuredAt = null;
+var permanentFailure = false;
+function isTransientSqliteError(err) {
+  const code = err?.code;
+  if (code === "SQLITE_BUSY" || code === "SQLITE_LOCKED" || code === "SQLITE_PROTOCOL") {
+    return true;
+  }
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return message.includes("database is locked") || message.includes("database table is locked") || message.includes("sqlite_busy") || message.includes("sqlite_locked");
+}
+function ensureFtsOnce() {
+  if (permanentFailure)
+    return { built: false, error: "fts-permanently-disabled" };
+  if (ensuredAt !== null && Date.now() - ensuredAt < TRANSIENT_RETRY_MS) {
+    return { built: false };
+  }
+  let db;
+  try {
+    db = new Database2(getDbPath());
+    db.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    const result = ensureFts(db);
+    ensuredAt = Date.now();
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const transient = isTransientSqliteError(err);
+    if (transient) {
+      ensuredAt = Date.now();
+    } else {
+      permanentFailure = true;
+    }
+    return { built: false, error: message, transient };
+  } finally {
+    db?.close();
+  }
+}
+function detectSchemaDrift(db) {
+  const samples = [
+    { type: "text", required: ["$.text"] },
+    { type: "tool", required: ["$.tool"] },
+    { type: "patch", required: ["$.files"] }
+  ];
+  for (const { type, required } of samples) {
+    const row = db.query(`SELECT data FROM part
+         WHERE json_valid(data) AND json_extract(data, '$.type') = ?
+         ORDER BY rowid DESC LIMIT 1`).get(type);
+    if (!row)
+      continue;
+    for (const key of required) {
+      const present = db.query(`SELECT json_type(?, ?) AS t`).get(row.data, key)?.t;
+      if (present === null || present === undefined) {
+        return `part type='${type}' missing expected key '${key}'`;
+      }
+    }
+  }
+  return null;
+}
+function ensureFts(db) {
+  ensureMetaTable(db);
+  const drift = detectSchemaDrift(db);
+  if (drift) {
+    console.warn(`[history-search] OpenCode schema drift detected (${drift}). ` + `Forcing FTS rebuild; if search results look wrong, update this plugin.`);
+    db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`);
+    db.exec(`DROP TABLE IF EXISTS ${TRI_TABLE}`);
+  }
+  const tableExists = db.query(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(FTS_TABLE);
+  if (tableExists && triggersExist(db) && versionMatches(db)) {
+    const watermark = readWatermark(db);
+    const maxPart = db.query(`SELECT COALESCE(MAX(rowid), 0) AS r FROM part`).get().r;
+    if (maxPart < watermark) {
+      writeWatermark(db, maxPart);
+      return { built: false };
+    }
+    if (maxPart > watermark) {
+      const t02 = performance.now();
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        db.query(`DELETE FROM ${FTS_TABLE}
+           WHERE part_id IN (SELECT id FROM part WHERE rowid >= ?)`).run(watermark + 1);
+        db.query(`DELETE FROM ${TRI_TABLE}
+           WHERE part_id IN (SELECT id FROM part WHERE rowid >= ?)`).run(watermark + 1);
+        backfillRange(db, watermark + 1);
+        writeWatermark(db, maxPart);
+        db.exec("COMMIT");
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+      return { built: false, built_ms: performance.now() - t02 };
+    }
+    return { built: false };
+  }
+  const t0 = performance.now();
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    buildFts(db);
+    installTriggers(db);
+    const maxPart = db.query(`SELECT COALESCE(MAX(rowid), 0) AS r FROM part`).get().r;
+    writeWatermark(db, maxPart);
+    recordVersion(db);
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+  return { built: true, built_ms: performance.now() - t0 };
+}
+function buildFts(db) {
+  db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`);
+  db.exec(`
+    CREATE VIRTUAL TABLE ${FTS_TABLE} USING fts5(
+      content,
+      kind UNINDEXED,
+      part_id UNINDEXED,
+      message_id UNINDEXED,
+      session_id UNINDEXED,
+      tokenize = 'unicode61 remove_diacritics 2'
+    );
+  `);
+  db.exec(`DROP TABLE IF EXISTS ${TRI_TABLE}`);
+  db.exec(`
+    CREATE VIRTUAL TABLE ${TRI_TABLE} USING fts5(
+      content,
+      kind UNINDEXED,
+      part_id UNINDEXED,
+      message_id UNINDEXED,
+      session_id UNINDEXED,
+      tokenize = 'trigram'
+    );
+  `);
+  backfillRange(db, 0);
+}
+function backfillRange(db, startRowid) {
+  db.exec(`
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT json_extract(data, '$.text'), 'text', id, message_id, session_id
+    FROM part
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
+      AND json_extract(data, '$.type') = 'text'
+      AND json_extract(data, '$.text') IS NOT NULL
+      AND json_extract(data, '$.text') != ''
+  `);
+  db.exec(`
+    INSERT INTO ${TRI_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT json_extract(data, '$.text'), 'text', id, message_id, session_id
+    FROM part
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
+      AND json_extract(data, '$.type') = 'text'
+      AND json_extract(data, '$.text') IS NOT NULL
+      AND json_extract(data, '$.text') != ''
+  `);
+  db.exec(`
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')),
+      'tool_name', id, message_id, session_id
+    FROM part
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
+      AND json_extract(data, '$.type') = 'tool'
+      AND json_extract(data, '$.tool') IS NOT NULL
+      AND trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')) != ''
+  `);
+  db.exec(`
+    INSERT INTO ${TRI_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')),
+      'tool_name', id, message_id, session_id
+    FROM part
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
+      AND json_extract(data, '$.type') = 'tool'
+      AND json_extract(data, '$.tool') IS NOT NULL
+      AND trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')) != ''
+  `);
+  db.exec(`
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(data, '$.state.input'), '') || ' ' || coalesce(json_extract(data, '$.state.output'), '')),
+      'tool_state', id, message_id, session_id
+    FROM part
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
+      AND json_extract(data, '$.type') = 'tool'
+      AND json_extract(data, '$.state') IS NOT NULL
+      AND trim(coalesce(json_extract(data, '$.state.input'), '') || ' ' || coalesce(json_extract(data, '$.state.output'), '')) != ''
+  `);
+  db.exec(`
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT j.value, 'patch_file', p.id, p.message_id, p.session_id
+    FROM (
+      SELECT id, message_id, session_id, json_extract(data, '$.files') AS files
+      FROM part
+      WHERE rowid >= ${startRowid}
+        AND json_valid(data)
+        AND json_extract(data, '$.type') = 'patch'
+        AND json_type(data, '$.files') = 'array'
+    ) p, json_each(p.files) j
+    WHERE j.value IS NOT NULL
+      AND j.value != ''
+  `);
+}
+var EXPECTED_TRIGGERS = ["part_fts_ai", "part_fts_ad", "part_fts_au"];
+function insertFromPartSql() {
+  return `
+    -- text: both tables
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT json_extract(NEW.data, '$.text'), 'text', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'text'
+        AND json_extract(NEW.data, '$.text') IS NOT NULL
+        AND json_extract(NEW.data, '$.text') != '';
+    INSERT INTO ${TRI_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT json_extract(NEW.data, '$.text'), 'text', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'text'
+        AND json_extract(NEW.data, '$.text') IS NOT NULL
+        AND json_extract(NEW.data, '$.text') != '';
+
+    -- tool_name: both tables
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')),
+      'tool_name', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'tool'
+        AND json_extract(NEW.data, '$.tool') IS NOT NULL
+        AND trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')) != '';
+    INSERT INTO ${TRI_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')),
+      'tool_name', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'tool'
+        AND json_extract(NEW.data, '$.tool') IS NOT NULL
+        AND trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')) != '';
+
+    -- tool_state: unicode61 only (too big + too noisy for fuzzy)
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(NEW.data, '$.state.input'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.output'), '')),
+      'tool_state', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'tool'
+        AND json_extract(NEW.data, '$.state') IS NOT NULL
+        AND trim(coalesce(json_extract(NEW.data, '$.state.input'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.output'), '')) != '';
+
+    -- patch_file: unicode61 only (exact path match, fuzzy doesn't help)
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT j.value, 'patch_file', NEW.id, NEW.message_id, NEW.session_id
+      FROM json_each(
+        CASE
+          WHEN json_valid(NEW.data)
+           AND json_extract(NEW.data, '$.type') = 'patch'
+           AND json_type(NEW.data, '$.files') = 'array'
+          THEN json_extract(NEW.data, '$.files')
+          ELSE '[]'
+        END
+      ) j
+      WHERE j.value IS NOT NULL
+        AND j.value != '';
+  `;
+}
+function triggersExist(db) {
+  const placeholders = EXPECTED_TRIGGERS.map(() => "?").join(",");
+  const rows = db.query(`SELECT name FROM sqlite_master WHERE type='trigger' AND name IN (${placeholders})`).all(...EXPECTED_TRIGGERS);
+  return rows.length === EXPECTED_TRIGGERS.length;
+}
+function installTriggers(db) {
+  for (const name of EXPECTED_TRIGGERS) {
+    db.exec(`DROP TRIGGER IF EXISTS ${name}`);
+  }
+  db.exec(`
+    CREATE TRIGGER part_fts_ai AFTER INSERT ON part
+    BEGIN
+      ${insertFromPartSql()}
+    END;
+  `);
+  db.exec(`
+    CREATE TRIGGER part_fts_ad AFTER DELETE ON part
+    BEGIN
+      DELETE FROM ${FTS_TABLE} WHERE part_id = OLD.id;
+      DELETE FROM ${TRI_TABLE} WHERE part_id = OLD.id;
+    END;
+  `);
+  db.exec(`
+    CREATE TRIGGER part_fts_au AFTER UPDATE ON part
+    BEGIN
+      DELETE FROM ${FTS_TABLE} WHERE part_id = OLD.id;
+      DELETE FROM ${TRI_TABLE} WHERE part_id = OLD.id;
+      ${insertFromPartSql()}
+    END;
+  `);
+}
+function ensureMetaTable(db) {
+  db.exec(`CREATE TABLE IF NOT EXISTS part_fts_meta (key TEXT PRIMARY KEY, value TEXT)`);
+}
+function versionMatches(db) {
+  const row = db.query(`SELECT value FROM part_fts_meta WHERE key = 'version'`).get();
+  return row?.value === String(FTS_VERSION);
+}
+function recordVersion(db) {
+  db.query(`INSERT OR REPLACE INTO part_fts_meta(key, value) VALUES('version', ?)`).run(String(FTS_VERSION));
+}
+function readWatermark(db) {
+  const row = db.query(`SELECT value FROM part_fts_meta WHERE key = 'last_rowid'`).get();
+  return row ? Number(row.value) : 0;
+}
+function writeWatermark(db, rowid) {
+  db.query(`INSERT OR REPLACE INTO part_fts_meta(key, value) VALUES('last_rowid', ?)`).run(String(rowid));
+}
+var warnedQueryError = false;
+function searchFts(db, query, opts) {
+  return runFtsQuery(db, FTS_TABLE, query, opts);
+}
+function searchFtsTrigram(db, query, opts) {
+  return runFtsQuery(db, TRI_TABLE, query, opts);
+}
+function runFtsQuery(db, table, query, opts) {
+  const where = [`${table}.content MATCH ?`];
+  const binds = [query];
+  if (opts.projectID) {
+    where.push("s.project_id = ?");
+    binds.push(opts.projectID);
+  }
+  if (opts.role) {
+    where.push("json_extract(m.data, '$.role') = ?");
+    binds.push(opts.role);
+  }
+  if (opts.startTime !== undefined) {
+    where.push("m.time_created >= ?");
+    binds.push(opts.startTime);
+  }
+  if (opts.endTime !== undefined) {
+    where.push("m.time_created <= ?");
+    binds.push(opts.endTime);
+  }
+  binds.push(opts.limit);
+  const sql = `
+    SELECT
+      ${table}.part_id    AS part_id,
+      ${table}.message_id AS message_id,
+      ${table}.session_id AS session_id,
+      ${table}.content    AS content,
+      ${table}.kind       AS kind,
+      m.time_created      AS time_created,
+      s.title             AS session_title,
+      s.directory         AS session_directory
+    FROM ${table}
+    JOIN message m ON m.id = ${table}.message_id
+    JOIN session s ON s.id = ${table}.session_id
+    WHERE ${where.join(" AND ")}
+    ORDER BY m.time_created DESC
+    LIMIT ?
+  `;
+  try {
+    return db.query(sql).all(...binds);
+  } catch (err) {
+    if (!warnedQueryError) {
+      warnedQueryError = true;
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[history-search] FTS query failed (${table}): ${message}`);
+    }
+    return [];
+  }
+}
+function escapeFtsPhrase(s) {
+  const cleaned = sanitizeQuery(s);
+  if (cleaned === null)
+    return null;
+  return `"${cleaned.replace(/"/g, '""')}"`;
+}
+function sanitizeQuery(s) {
+  const cleaned = s.replace(/[\u0000-\u001f]/g, " ").trim();
+  if (cleaned === "")
+    return null;
+  if (!/[\p{L}\p{N}]/u.test(cleaned))
+    return null;
+  return cleaned;
+}
+function searchTitles(db, query, opts) {
+  const cleaned = sanitizeQuery(query);
+  if (cleaned === null)
+    return [];
+  const like = `%${cleaned.replace(/[\\%_]/g, (c) => "\\" + c)}%`;
+  const sql = `
+    SELECT id, title, directory, time_updated
+    FROM session
+    WHERE title LIKE ? ESCAPE '\\'
+      ${opts.projectID ? "AND project_id = ?" : ""}
+    ORDER BY time_updated DESC
+    LIMIT ?
+  `;
+  const binds = [like];
+  if (opts.projectID)
+    binds.push(opts.projectID);
+  binds.push(opts.limit);
+  return db.query(sql).all(...binds);
+}
+
 // src/storage-provider.ts
-var useSqlite = dbExists();
+function useSqlite() {
+  return dbExists();
+}
+var warnedFtsError = false;
+async function withSqlite(fn) {
+  if (!useSqlite())
+    return null;
+  const ftsResult = ensureFtsOnce();
+  if (ftsResult.error && !ftsResult.transient && !warnedFtsError) {
+    warnedFtsError = true;
+    console.warn(`[history-search] FTS5 index unavailable: ${ftsResult.error}. ` + `Falling back to slower row-scan search. ` + `See README "Rollback" section if you want to remove the index entirely.`);
+  } else if (ftsResult.built && ftsResult.built_ms !== undefined) {
+    console.warn(`[history-search] Built FTS5 search index in ${Math.round(ftsResult.built_ms)}ms ` + `(one-time setup, see README "Rollback" to remove).`);
+  }
+  return await withDb(fn);
+}
 async function* listSessions2(projectID) {
-  if (useSqlite) {
+  if (useSqlite()) {
     yield* listSessionsSqlite(projectID);
   } else {
     yield* listSessions(projectID);
   }
 }
 async function* listMessages2(sessionID, role) {
-  if (useSqlite) {
+  if (useSqlite()) {
     yield* listMessagesSqlite(sessionID, role);
   } else {
     yield* listMessages(sessionID, role);
   }
 }
 async function* listParts2(messageID) {
-  if (useSqlite) {
+  if (useSqlite()) {
     yield* listPartsSqlite(messageID);
   } else {
     yield* listParts(messageID);
@@ -228,8 +693,139 @@ async function* listParts2(messageID) {
 
 // src/search/keyword.ts
 async function searchKeyword(projectID, query, options = {}) {
+  const fast = await withSqlite((db) => {
+    if (options.regex) {
+      return searchKeywordSqlite(db, projectID, query, options);
+    }
+    return searchKeywordFts(db, projectID, query, options);
+  });
+  if (fast !== null)
+    return fast;
+  return searchKeywordGenerators(projectID, query, options);
+}
+function buildPattern(query, options) {
+  return options.regex ? new RegExp(query, options.caseSensitive ? "" : "i") : new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), options.caseSensitive ? "" : "i");
+}
+function searchKeywordFts(db, projectID, query, options) {
+  const limit = options.limit || 50;
+  const phrase = escapeFtsPhrase(query);
+  if (phrase === null) {
+    return searchKeywordSqlite(db, projectID, query, options);
+  }
+  const out = [];
+  const titles = searchTitles(db, query, { projectID, limit });
+  for (const t of titles) {
+    if (out.length >= limit)
+      break;
+    out.push({
+      sessionID: t.id,
+      sessionTitle: t.title,
+      timestamp: t.time_updated,
+      matchType: "title",
+      excerpt: t.title,
+      context: t.title,
+      projectDirectory: t.directory
+    });
+  }
+  const overfetch = Math.min(limit * 3, 500);
+  const hits = searchFts(db, phrase, {
+    projectID,
+    role: options.role,
+    startTime: options.startTime,
+    endTime: options.endTime,
+    limit: overfetch
+  });
+  const pattern = buildPattern(query, options);
+  const seen = new Set;
+  for (const hit of hits) {
+    if (out.length >= limit)
+      break;
+    const m = ftsHitToSearchMatch(hit, query, pattern);
+    const key = `${hit.part_id}|${m.matchType}|${m.excerpt}`;
+    if (seen.has(key))
+      continue;
+    seen.add(key);
+    out.push(m);
+  }
+  return out.sort((a, b) => b.timestamp - a.timestamp);
+}
+function ftsHitToSearchMatch(hit, query, pattern) {
+  const base = {
+    sessionID: hit.session_id,
+    sessionTitle: hit.session_title,
+    timestamp: hit.time_created,
+    messageID: hit.message_id,
+    partID: hit.part_id,
+    projectDirectory: hit.session_directory
+  };
+  const content = hit.content;
+  const m = pattern.exec(content);
+  const idx = m?.index ?? 0;
+  const contextStart = Math.max(0, idx - 100);
+  const contextEnd = Math.min(content.length, idx + (m?.[0].length ?? query.length) + 100);
+  const excerpt = m?.[0] ?? query;
+  const context = content.slice(contextStart, contextEnd);
+  switch (hit.kind) {
+    case "text":
+      return { ...base, matchType: "message", excerpt, context };
+    case "tool_name":
+    case "tool_state":
+      return { ...base, matchType: "tool", excerpt, context };
+    case "patch_file":
+      return {
+        ...base,
+        matchType: "filepath",
+        excerpt: content,
+        context: `Modified file: ${content}`
+      };
+    default: {
+      const _exhaustive = hit.kind;
+      throw new Error(`unhandled FtsKind: ${String(_exhaustive)}`);
+    }
+  }
+}
+function searchKeywordSqlite(db, projectID, query, options) {
+  const pattern = buildPattern(query, options);
+  const limit = options.limit || 50;
   const results = [];
-  const pattern = options.regex ? new RegExp(query, options.caseSensitive ? "" : "i") : new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), options.caseSensitive ? "" : "i");
+  const sessions = listSessionRowsSync(db, projectID);
+  for (const session of sessions) {
+    if (results.length >= limit)
+      break;
+    if (pattern.test(session.title)) {
+      results.push({
+        sessionID: session.id,
+        sessionTitle: session.title,
+        timestamp: session.time.updated,
+        matchType: "title",
+        excerpt: session.title,
+        context: session.title,
+        projectDirectory: session.directory
+      });
+      if (results.length >= limit)
+        break;
+    }
+    const messages = listMessageRowsSync(db, session.id, options.role);
+    for (const message of messages) {
+      if (results.length >= limit)
+        break;
+      if (options.startTime !== undefined && message.time.created < options.startTime)
+        continue;
+      if (options.endTime !== undefined && message.time.created > options.endTime)
+        continue;
+      const parts = listPartRowsSync(db, message.id);
+      for (const part of parts) {
+        if (results.length >= limit)
+          break;
+        matchPart(results, pattern, query, session, message, part, limit);
+      }
+    }
+  }
+  return results.sort((a, b) => b.timestamp - a.timestamp);
+}
+async function searchKeywordGenerators(projectID, query, options) {
+  const results = [];
+  const pattern = buildPattern(query, options);
   const limit = options.limit || 50;
   for await (const session of listSessions2(projectID)) {
     if (results.length >= limit)
@@ -241,7 +837,8 @@ async function searchKeyword(projectID, query, options = {}) {
         timestamp: session.time.updated,
         matchType: "title",
         excerpt: session.title,
-        context: session.title
+        context: session.title,
+        projectDirectory: session.directory
       });
       if (results.length >= limit)
         break;
@@ -252,90 +849,91 @@ async function searchKeyword(projectID, query, options = {}) {
       for await (const part of listParts2(message.id)) {
         if (results.length >= limit)
           break;
-        if (part.type === "text" && part.text && pattern.test(part.text)) {
-          const match = part.text.match(pattern);
-          const matchIndex = match ? part.text.indexOf(match[0]) : 0;
-          const contextStart = Math.max(0, matchIndex - 100);
-          const contextEnd = Math.min(part.text.length, matchIndex + match[0].length + 100);
-          const context = part.text.slice(contextStart, contextEnd);
-          results.push({
-            sessionID: session.id,
-            sessionTitle: session.title,
-            timestamp: message.time.created,
-            matchType: "message",
-            excerpt: match ? match[0] : query,
-            context,
-            messageID: message.id,
-            partID: part.id,
-            projectDirectory: session.directory
-          });
-          if (results.length >= limit)
-            break;
-        }
-        if (results.length >= limit)
-          break;
-        if (part.type === "tool" && part.tool && pattern.test(part.tool)) {
-          results.push({
-            sessionID: session.id,
-            sessionTitle: session.title,
-            timestamp: message.time.created,
-            matchType: "tool",
-            excerpt: part.tool,
-            context: part.state?.title || part.tool,
-            messageID: message.id,
-            partID: part.id,
-            projectDirectory: session.directory
-          });
-          if (results.length >= limit)
-            break;
-        }
-        if (results.length >= limit)
-          break;
-        if (part.type === "tool" && part.state) {
-          const inputStr = JSON.stringify(part.state.input || {});
-          const outputStr = part.state.output || "";
-          if (pattern.test(inputStr) || pattern.test(outputStr)) {
-            const matched = pattern.exec(inputStr) || pattern.exec(outputStr);
-            if (matched) {
-              results.push({
-                sessionID: session.id,
-                sessionTitle: session.title,
-                timestamp: message.time.created,
-                matchType: "filepath",
-                excerpt: matched[0],
-                context: part.state.title || part.tool || "",
-                messageID: message.id,
-                partID: part.id,
-                projectDirectory: session.directory
-              });
-              if (results.length >= limit)
-                break;
-            }
-          }
-        }
-        if (results.length < limit && part.type === "patch" && part.files) {
-          for (const filePath of part.files) {
-            if (results.length >= limit)
-              break;
-            if (pattern.test(filePath)) {
-              results.push({
-                sessionID: session.id,
-                sessionTitle: session.title,
-                timestamp: message.time.created,
-                matchType: "filepath",
-                excerpt: filePath,
-                context: `Modified file: ${filePath}`,
-                messageID: message.id,
-                partID: part.id,
-                projectDirectory: session.directory
-              });
-            }
-          }
-        }
+        matchPart(results, pattern, query, session, message, part, limit);
       }
     }
   }
   return results.sort((a, b) => b.timestamp - a.timestamp);
+}
+function matchPart(results, pattern, query, session, message, part, limit) {
+  if (results.length >= limit)
+    return;
+  if (part.type === "text" && part.text && pattern.test(part.text)) {
+    const match = part.text.match(pattern);
+    const matchIndex = match ? part.text.indexOf(match[0]) : 0;
+    const contextStart = Math.max(0, matchIndex - 100);
+    const contextEnd = Math.min(part.text.length, matchIndex + match[0].length + 100);
+    const context = part.text.slice(contextStart, contextEnd);
+    results.push({
+      sessionID: session.id,
+      sessionTitle: session.title,
+      timestamp: message.time.created,
+      matchType: "message",
+      excerpt: match ? match[0] : query,
+      context,
+      messageID: message.id,
+      partID: part.id,
+      projectDirectory: session.directory
+    });
+    if (results.length >= limit)
+      return;
+  }
+  if (part.type === "tool" && part.tool && pattern.test(part.tool)) {
+    results.push({
+      sessionID: session.id,
+      sessionTitle: session.title,
+      timestamp: message.time.created,
+      matchType: "tool",
+      excerpt: part.tool,
+      context: part.state?.title || part.tool,
+      messageID: message.id,
+      partID: part.id,
+      projectDirectory: session.directory
+    });
+    if (results.length >= limit)
+      return;
+  }
+  if (part.type === "tool" && part.state) {
+    const inputStr = JSON.stringify(part.state.input || {});
+    const outputStr = part.state.output || "";
+    if (pattern.test(inputStr) || pattern.test(outputStr)) {
+      const matched = pattern.exec(inputStr) || pattern.exec(outputStr);
+      if (matched) {
+        results.push({
+          sessionID: session.id,
+          sessionTitle: session.title,
+          timestamp: message.time.created,
+          matchType: "filepath",
+          excerpt: matched[0],
+          context: part.state.title || part.tool || "",
+          messageID: message.id,
+          partID: part.id,
+          projectDirectory: session.directory
+        });
+        if (results.length >= limit)
+          return;
+      }
+    }
+  }
+  if (part.type === "patch" && part.files) {
+    for (const filePath of part.files) {
+      if (results.length >= limit)
+        return;
+      if (pattern.test(filePath)) {
+        results.push({
+          sessionID: session.id,
+          sessionTitle: session.title,
+          timestamp: message.time.created,
+          matchType: "filepath",
+          excerpt: filePath,
+          context: `Modified file: ${filePath}`,
+          messageID: message.id,
+          partID: part.id,
+          projectDirectory: session.directory
+        });
+      }
+    }
+  }
 }
 
 // node_modules/fuse.js/dist/fuse.mjs
@@ -1634,8 +2232,70 @@ Fuse.config = Config;
 
 // src/search/fuzzy.ts
 async function searchFuzzy(projectID, query, options = {}) {
-  const threshold = options.threshold ?? 0.4;
+  const fast = await withSqlite((db) => searchFuzzyTrigram(db, projectID, query, options));
+  if (fast !== null)
+    return fast;
+  return searchFuzzyGenerators(projectID, query, options);
+}
+function searchFuzzyTrigram(db, projectID, query, options) {
   const limit = options.limit ?? 50;
+  const phrase = escapeFtsPhrase(query);
+  if (phrase === null)
+    return [];
+  const out = [];
+  const titles = searchTitles(db, query, { projectID, limit });
+  for (const t of titles) {
+    if (out.length >= limit)
+      break;
+    out.push({
+      sessionID: t.id,
+      sessionTitle: t.title,
+      timestamp: t.time_updated,
+      matchType: "title",
+      excerpt: t.title,
+      context: t.title,
+      projectDirectory: t.directory
+    });
+  }
+  const overfetch = Math.min(limit * 3, 500);
+  const hits = searchFtsTrigram(db, phrase, {
+    projectID,
+    role: options.role,
+    startTime: options.startTime,
+    endTime: options.endTime,
+    limit: overfetch
+  });
+  const seen = new Set;
+  for (const hit of hits) {
+    if (out.length >= limit)
+      break;
+    const m = ftsHitToFuzzyMatch(hit, query);
+    const key = `${hit.part_id}|${m.matchType}|${m.excerpt}`;
+    if (seen.has(key))
+      continue;
+    seen.add(key);
+    out.push(m);
+  }
+  return out.sort((a, b) => b.timestamp - a.timestamp);
+}
+function ftsHitToFuzzyMatch(hit, query) {
+  const content = hit.content;
+  const excerpt = content.slice(0, 100) || query;
+  const context = content.slice(0, 300) || excerpt;
+  const matchType = hit.kind === "text" ? "message" : "tool";
+  return {
+    sessionID: hit.session_id,
+    sessionTitle: hit.session_title,
+    timestamp: hit.time_created,
+    matchType,
+    excerpt,
+    context,
+    messageID: hit.message_id,
+    partID: hit.part_id,
+    projectDirectory: hit.session_directory
+  };
+}
+async function searchFuzzyGenerators(projectID, query, options) {
   const items = [];
   try {
     for await (const session of listSessions2(projectID)) {
@@ -1649,56 +2309,7 @@ async function searchFuzzy(projectID, query, options = {}) {
         for await (const message of listMessages2(session.id, options.role)) {
           try {
             for await (const part of listParts2(message.id)) {
-              if (part.type === "text" && part.text) {
-                items.push({
-                  session,
-                  content: part.text,
-                  type: "message",
-                  messageID: message.id,
-                  partID: part.id,
-                  timestamp: message.time.created
-                });
-              }
-              if (part.type === "tool" && part.tool) {
-                items.push({
-                  session,
-                  content: part.tool + " " + (part.state?.title || ""),
-                  type: "tool",
-                  messageID: message.id,
-                  partID: part.id,
-                  timestamp: message.time.created
-                });
-              }
-              if (part.type === "tool" && part.state) {
-                const inputStr = JSON.stringify(part.state.input || {});
-                const outputStr = part.state.output || "";
-                const combined = inputStr + " " + outputStr;
-                const pathMatches = combined.match(/(?:\/[^/\s]+)+/g);
-                if (pathMatches) {
-                  for (const path3 of pathMatches) {
-                    items.push({
-                      session,
-                      content: path3,
-                      type: "filepath",
-                      messageID: message.id,
-                      partID: part.id,
-                      timestamp: message.time.created
-                    });
-                  }
-                }
-              }
-              if (part.type === "patch" && part.files) {
-                for (const filePath of part.files) {
-                  items.push({
-                    session,
-                    content: filePath,
-                    type: "filepath",
-                    messageID: message.id,
-                    partID: part.id,
-                    timestamp: message.time.created
-                  });
-                }
-              }
+              addPartItems(items, session, message, part);
             }
           } catch {
             continue;
@@ -1711,6 +2322,63 @@ async function searchFuzzy(projectID, query, options = {}) {
   } catch {
     return [];
   }
+  return runFuse(items, query, options);
+}
+function addPartItems(items, session, message, part) {
+  if (part.type === "text" && part.text) {
+    items.push({
+      session,
+      content: part.text,
+      type: "message",
+      messageID: message.id,
+      partID: part.id,
+      timestamp: message.time.created
+    });
+  }
+  if (part.type === "tool" && part.tool) {
+    items.push({
+      session,
+      content: part.tool + " " + (part.state?.title || ""),
+      type: "tool",
+      messageID: message.id,
+      partID: part.id,
+      timestamp: message.time.created
+    });
+  }
+  if (part.type === "tool" && part.state) {
+    const inputStr = JSON.stringify(part.state.input || {});
+    const outputStr = part.state.output || "";
+    const combined = inputStr + " " + outputStr;
+    const pathMatches = combined.match(/(?:\/[^/\s]+)+/g);
+    if (pathMatches) {
+      for (const p of pathMatches) {
+        items.push({
+          session,
+          content: p,
+          type: "filepath",
+          messageID: message.id,
+          partID: part.id,
+          timestamp: message.time.created
+        });
+      }
+    }
+  }
+  if (part.type === "patch" && part.files) {
+    for (const filePath of part.files) {
+      items.push({
+        session,
+        content: filePath,
+        type: "filepath",
+        messageID: message.id,
+        partID: part.id,
+        timestamp: message.time.created
+      });
+    }
+  }
+}
+function runFuse(items, query, options) {
+  const threshold = options.threshold ?? 0.4;
+  const limit = options.limit ?? 50;
   const fuse = new Fuse(items, {
     keys: ["content"],
     threshold,
@@ -1955,9 +2623,9 @@ function isMatch(path3, query, isExact) {
   return path3 === query || path3.endsWith(`/${query}`);
 }
 async function traceFile(projectID, filePath, options) {
-  const { Database: Database2 } = await import("bun:sqlite");
+  const { Database: Database3 } = await import("bun:sqlite");
   const dbPath = getDbPath();
-  const db = new Database2(dbPath, { readonly: true });
+  const db = new Database3(dbPath, { readonly: true });
   try {
     return traceFileSqlite(db, projectID, filePath, options);
   } finally {
@@ -2038,20 +2706,24 @@ var historySearch = tool({
     if (!args.query && !args.filePath) {
       throw new Error("Either 'query' or 'filePath' must be provided.");
     }
+    if (args.query !== undefined && args.query.length > 1024) {
+      throw new Error(`'query' is too long (${args.query.length} chars; max 1024).`);
+    }
     const projectID = args.searchAllProjects ? null : await getCurrentProjectID();
+    const dateRange = args.date ? parseDateFilter(args.date) : null;
     if (args.filePath) {
       let matches2 = await traceFile(projectID, args.filePath, {
         limit: args.limit
       });
-      if (args.date) {
-        const dateRange = parseDateFilter(args.date);
+      if (dateRange)
         matches2 = filterByDate(matches2, dateRange);
-      }
       return formatTraceResults(matches2);
     }
     if (!args.query) {
       throw new Error("'query' is required when 'filePath' is not provided.");
     }
+    const startTime = dateRange?.start.getTime();
+    const endTime = dateRange?.end.getTime();
     let matches = args.mode === "fuzzy" ? await searchFuzzy(projectID, args.query, {
       threshold: args.fuzzyThreshold,
       limit: args.limit,
@@ -2060,12 +2732,12 @@ var historySearch = tool({
       regex: args.regex,
       caseSensitive: args.caseSensitive,
       limit: args.limit,
-      role: args.role
+      role: args.role,
+      startTime,
+      endTime
     });
-    if (args.date) {
-      const dateRange = parseDateFilter(args.date);
+    if (dateRange)
       matches = filterByDate(matches, dateRange);
-    }
     return formatResults(matches);
   }
 });

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "install:tool": "bun run install.ts",
-    "test": "bun test src/storage.test.ts src/storage-sqlite.test.ts src/search/keyword.test.ts src/search/fuzzy.test.ts src/search/date-filter.test.ts src/search/file-trace.test.ts src/format.test.ts",
-    "test:unit": "bun test src/storage.test.ts src/storage-sqlite.test.ts src/search/keyword.test.ts src/search/fuzzy.test.ts src/search/date-filter.test.ts src/search/file-trace.test.ts src/format.test.ts",
+    "test": "bun test src/storage.test.ts src/storage-sqlite.test.ts src/search/keyword.test.ts src/search/fuzzy.test.ts src/search/date-filter.test.ts src/search/file-trace.test.ts src/search/fts.test.ts src/format.test.ts",
+    "test:unit": "bun test src/storage.test.ts src/storage-sqlite.test.ts src/search/keyword.test.ts src/search/fuzzy.test.ts src/search/date-filter.test.ts src/search/file-trace.test.ts src/search/fts.test.ts src/format.test.ts",
     "test:integration": "bun test src/**/*.integration.test.ts test/date-filter-integration.test.ts test/global-integration.test.ts",
     "test:all": "bun run test:unit && bun run test:integration",
     "build": "bun run build.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,18 +69,26 @@ const historySearch = tool({
       throw new Error("Either 'query' or 'filePath' must be provided.");
     }
 
+    // Bound the query length to prevent runaway memory allocation if an LLM
+    // generates a pathologically large prompt. 1024 chars is far more than any
+    // reasonable search.
+    if (args.query !== undefined && args.query.length > 1024) {
+      throw new Error(
+        `'query' is too long (${args.query.length} chars; max 1024).`,
+      );
+    }
+
     const projectID = args.searchAllProjects ? null : await getCurrentProjectID();
+
+    // Parse the date filter ONCE so the same range is used for both the
+    // SQL pushdown (fast path) and the post-filter (fallback path).
+    const dateRange = args.date ? parseDateFilter(args.date) : null;
 
     if (args.filePath) {
       let matches = await traceFile(projectID, args.filePath, {
         limit: args.limit,
       });
-
-      if (args.date) {
-        const dateRange = parseDateFilter(args.date);
-        matches = filterByDate(matches, dateRange);
-      }
-
+      if (dateRange) matches = filterByDate(matches, dateRange);
       return formatTraceResults(matches);
     }
 
@@ -88,6 +96,9 @@ const historySearch = tool({
     if (!args.query) {
       throw new Error("'query' is required when 'filePath' is not provided.");
     }
+
+    const startTime = dateRange?.start.getTime();
+    const endTime = dateRange?.end.getTime();
 
     let matches =
       args.mode === "fuzzy"
@@ -101,12 +112,14 @@ const historySearch = tool({
             caseSensitive: args.caseSensitive,
             limit: args.limit,
             role: args.role,
+            startTime,
+            endTime,
           });
 
-    if (args.date) {
-      const dateRange = parseDateFilter(args.date);
-      matches = filterByDate(matches, dateRange);
-    }
+    // Belt-and-suspenders: if the search path didn't honor the date range
+    // (fuzzy doesn't, regex fallback might not have the time index loaded),
+    // apply the JS-side date filter as a final pass.
+    if (dateRange) matches = filterByDate(matches, dateRange);
 
     return formatResults(matches);
   },

--- a/src/search/fts.test.ts
+++ b/src/search/fts.test.ts
@@ -3,6 +3,7 @@ import { Database } from "bun:sqlite";
 import {
   ensureFts,
   searchFts,
+  searchFtsTrigram,
   escapeFtsPhrase,
   searchTitles,
 } from "./fts";
@@ -125,7 +126,7 @@ describe("FTS5 module", () => {
         `SELECT value FROM part_fts_meta WHERE key='version'`,
       )
       .get()?.value;
-    expect(version).toBe("4");
+    expect(version).toBe("5");
 
     // Watermark recorded so incremental backfill works
     const watermark = db
@@ -210,6 +211,75 @@ describe("FTS5 module", () => {
     expect(hits.length).toBe(1);
     expect(hits[0]?.id).toBe("s2");
   });
+
+  test("trigram index populated for text and tool_name only", () => {
+    const counts = db
+      .query<{ kind: string; n: number }, []>(
+        `SELECT kind, COUNT(*) n FROM part_fts_tri GROUP BY kind ORDER BY kind`,
+      )
+      .all();
+    const map = Object.fromEntries(counts.map((c) => [c.kind, c.n]));
+    expect(map.text).toBeGreaterThan(0);
+    expect(map.tool_name).toBeGreaterThan(0);
+    // tool_state and patch_file are NOT trigram-indexed (too big/noisy).
+    expect(map.tool_state).toBeUndefined();
+    expect(map.patch_file).toBeUndefined();
+  });
+
+  test("trigram fuzzy MATCH tolerates a missing letter", () => {
+    // "storage" is in p1's text; "storag" (missing 'e') should match via trigrams.
+    const hits = searchFtsTrigram(db, '"storag"', {
+      projectID: null,
+      limit: 10,
+    });
+    expect(hits.some((h) => h.part_id === "p1")).toBe(true);
+  });
+
+  test("trigram fuzzy MATCH finds substring within word", () => {
+    // "authent" is a substring of "authentication" in p4.
+    const hits = searchFtsTrigram(db, '"authent"', {
+      projectID: null,
+      limit: 10,
+    });
+    expect(hits.some((h) => h.part_id === "p4")).toBe(true);
+  });
+
+  test("trigram fuzzy MATCH respects projectID filter", () => {
+    // Insert fixture content into a second project (proj2) and search with
+    // projectID=proj1; the proj2 row must not leak across. The test schema
+    // doesn't have a `project` table (only `session.project_id`), so we just
+    // use a new project_id string directly on a session row.
+    db.query(
+      `INSERT INTO session VALUES ('s_proj2','proj2','Other proj','/mock2',1,1)`,
+    ).run();
+    db.query(
+      `INSERT INTO message VALUES ('m_proj2','s_proj2',1,1,'${JSON.stringify(
+        { role: "assistant" },
+      ).replace(/'/g, "''")}')`,
+    ).run();
+    db.query(
+      `INSERT INTO part VALUES ('p_proj2','m_proj2','s_proj2',1,1,'${JSON.stringify(
+        { type: "text", text: "storage in another project" },
+      ).replace(/'/g, "''")}')`,
+    ).run();
+
+    const scoped = searchFtsTrigram(db, '"storag"', {
+      projectID: "proj1",
+      limit: 50,
+    });
+    // proj1 has p1 with "storage". Should match.
+    expect(scoped.some((h) => h.part_id === "p1")).toBe(true);
+    // proj2's row must NOT appear in proj1-scoped search.
+    expect(scoped.some((h) => h.part_id === "p_proj2")).toBe(false);
+
+    // Global search should see both.
+    const global = searchFtsTrigram(db, '"storag"', {
+      projectID: null,
+      limit: 50,
+    });
+    expect(global.some((h) => h.part_id === "p1")).toBe(true);
+    expect(global.some((h) => h.part_id === "p_proj2")).toBe(true);
+  });
 });
 
 describe("escapeFtsPhrase", () => {
@@ -263,11 +333,15 @@ describe("triggers tolerate malformed part.data without breaking inserts", () =>
     const row = db.query(`SELECT id FROM part WHERE id='bad1'`).get();
     expect(row).toBeDefined();
 
-    // ...but NOT in part_fts (trigger silently skipped it)
+    // ...but NOT in either FTS table (trigger silently skipped on both)
     const ftsRow = db
       .query(`SELECT part_id FROM part_fts WHERE part_id='bad1'`)
       .get();
     expect(ftsRow).toBeNull();
+    const triRow = db
+      .query(`SELECT part_id FROM part_fts_tri WHERE part_id='bad1'`)
+      .get();
+    expect(triRow).toBeNull();
   });
 
   test("UPDATE of malformed data does NOT abort", () => {
@@ -286,10 +360,15 @@ describe("triggers tolerate malformed part.data without breaking inserts", () =>
     }).not.toThrow();
 
     // FTS row should be deleted (DELETE trigger part runs) but no re-insert
+    // on either table — both DELETE statements ran inside the trigger body.
     ftsRow = db
       .query(`SELECT part_id FROM part_fts WHERE part_id='good1'`)
       .get();
     expect(ftsRow).toBeNull();
+    const triRow = db
+      .query(`SELECT part_id FROM part_fts_tri WHERE part_id='good1'`)
+      .get();
+    expect(triRow).toBeNull();
   });
 
   test("DELETE removes FTS rows", () => {
@@ -301,11 +380,21 @@ describe("triggers tolerate malformed part.data without breaking inserts", () =>
       .get();
     expect(ftsRow).toBeDefined();
 
+    // Trigram table should also have a row for a 'text' part.
+    let triRow = db
+      .query(`SELECT part_id FROM part_fts_tri WHERE part_id='del1'`)
+      .get();
+    expect(triRow).toBeDefined();
+
     db.query(`DELETE FROM part WHERE id='del1'`).run();
     ftsRow = db
       .query(`SELECT part_id FROM part_fts WHERE part_id='del1'`)
       .get();
     expect(ftsRow).toBeNull();
+    triRow = db
+      .query(`SELECT part_id FROM part_fts_tri WHERE part_id='del1'`)
+      .get();
+    expect(triRow).toBeNull();
   });
 
   // F1 regression: json_each used to crash the trigger if $.files was a

--- a/src/search/fts.test.ts
+++ b/src/search/fts.test.ts
@@ -125,7 +125,15 @@ describe("FTS5 module", () => {
         `SELECT value FROM part_fts_meta WHERE key='version'`,
       )
       .get()?.value;
-    expect(version).toBe("2");
+    expect(version).toBe("4");
+
+    // Watermark recorded so incremental backfill works
+    const watermark = db
+      .query<{ value: string }, []>(
+        `SELECT value FROM part_fts_meta WHERE key='last_rowid'`,
+      )
+      .get()?.value;
+    expect(Number(watermark)).toBeGreaterThan(0);
   });
 
   test("ensureFts is idempotent (no rebuild on second call)", () => {
@@ -299,6 +307,254 @@ describe("triggers tolerate malformed part.data without breaking inserts", () =>
       .get();
     expect(ftsRow).toBeNull();
   });
+
+  // F1 regression: json_each used to crash the trigger if $.files was a
+  // syntactically-valid JSON value that wasn't an array (string, object,
+  // number, etc). That crashed the parent INSERT, breaking OpenCode. The fix
+  // wraps json_each in a CASE WHEN json_type=array guard.
+  test("F1: patch with $.files as a string does NOT abort INSERT", () => {
+    expect(() => {
+      db.query(
+        `INSERT INTO part VALUES ('bad-patch-str','m1','s1',9100,9100,
+         '${JSON.stringify({ type: "patch", files: "oops-just-a-string" }).replace(/'/g, "''")}')`,
+      ).run();
+    }).not.toThrow();
+
+    expect(db.query(`SELECT id FROM part WHERE id='bad-patch-str'`).get()).toBeDefined();
+    expect(
+      db.query(`SELECT part_id FROM part_fts WHERE part_id='bad-patch-str'`).get(),
+    ).toBeNull();
+  });
+
+  test("F1: patch with $.files as an object does NOT abort INSERT", () => {
+    expect(() => {
+      db.query(
+        `INSERT INTO part VALUES ('bad-patch-obj','m1','s1',9200,9200,
+         '${JSON.stringify({ type: "patch", files: { not: "an array" } }).replace(/'/g, "''")}')`,
+      ).run();
+    }).not.toThrow();
+    expect(
+      db.query(`SELECT part_id FROM part_fts WHERE part_id='bad-patch-obj'`).get(),
+    ).toBeNull();
+  });
+
+  test("F1: patch with $.files as a number does NOT abort INSERT", () => {
+    expect(() => {
+      db.query(
+        `INSERT INTO part VALUES ('bad-patch-num','m1','s1',9300,9300,
+         '${JSON.stringify({ type: "patch", files: 42 }).replace(/'/g, "''")}')`,
+      ).run();
+    }).not.toThrow();
+    expect(
+      db.query(`SELECT part_id FROM part_fts WHERE part_id='bad-patch-num'`).get(),
+    ).toBeNull();
+  });
+
+  test("F1: patch with missing $.files does NOT abort INSERT", () => {
+    expect(() => {
+      db.query(
+        `INSERT INTO part VALUES ('bad-patch-mis','m1','s1',9400,9400,
+         '${JSON.stringify({ type: "patch" }).replace(/'/g, "''")}')`,
+      ).run();
+    }).not.toThrow();
+    expect(
+      db.query(`SELECT part_id FROM part_fts WHERE part_id='bad-patch-mis'`).get(),
+    ).toBeNull();
+  });
+
+  test("F1: patch with valid array $.files still indexes correctly", () => {
+    expect(() => {
+      db.query(
+        `INSERT INTO part VALUES ('good-patch','m1','s1',9500,9500,
+         '${JSON.stringify({ type: "patch", files: ["x.ts", "y.ts"] }).replace(/'/g, "''")}')`,
+      ).run();
+    }).not.toThrow();
+    const rows = db
+      .query<{ content: string }, []>(
+        `SELECT content FROM part_fts WHERE part_id='good-patch' AND kind='patch_file' ORDER BY content`,
+      )
+      .all();
+    expect(rows.map((r) => r.content)).toEqual(["x.ts", "y.ts"]);
+  });
+});
+
+describe("F1: backfill tolerates a non-array $.files among valid rows", () => {
+  test("a bad patch row does not blow up the full build", () => {
+    const db = new Database(":memory:");
+    makeSchema(db);
+    // Insert a known-bad row BEFORE building the index. If the backfill's
+    // json_each isn't guarded, this will abort the entire BEGIN IMMEDIATE
+    // transaction and the build will throw.
+    db.query(
+      `INSERT INTO part VALUES ('bad','m1','s1',5000,5000,
+       '${JSON.stringify({ type: "patch", files: "string-not-array" }).replace(/'/g, "''")}')`,
+    ).run();
+    db.query(
+      `INSERT INTO part VALUES ('ok','m1','s1',5001,5001,
+       '${JSON.stringify({ type: "patch", files: ["good.ts"] }).replace(/'/g, "''")}')`,
+    ).run();
+
+    expect(() => ensureFts(db)).not.toThrow();
+
+    // Bad row contributed zero FTS rows; good row contributed one.
+    // (makeSchema's p3 patch contributes 2 more — total 3 patch_file rows.)
+    const badRows = db
+      .query<{ part_id: string }, []>(
+        `SELECT part_id FROM part_fts WHERE part_id='bad'`,
+      )
+      .all();
+    expect(badRows.length).toBe(0);
+
+    const okRows = db
+      .query<{ content: string }, []>(
+        `SELECT content FROM part_fts WHERE part_id='ok' AND kind='patch_file'`,
+      )
+      .all();
+    expect(okRows.length).toBe(1);
+    expect(okRows[0]?.content).toBe("good.ts");
+    db.close();
+  });
+});
+
+describe("incremental backfill via rowid watermark", () => {
+  test("rows inserted while plugin was 'offline' are picked up on next ensureFts", () => {
+    const db = new Database(":memory:");
+    makeSchema(db);
+    ensureFts(db);
+
+    // Simulate "plugin offline": drop the triggers, insert a row, restore.
+    db.exec(`DROP TRIGGER part_fts_ai`);
+    db.exec(`DROP TRIGGER part_fts_au`);
+    db.exec(`DROP TRIGGER part_fts_ad`);
+
+    db.query(
+      `INSERT INTO part VALUES ('offline','m1','s1',6000,6000,
+       '${JSON.stringify({ type: "text", text: "missed by triggers" }).replace(/'/g, "''")}')`,
+    ).run();
+
+    // Sanity: the FTS row is NOT there yet
+    expect(
+      db.query(`SELECT part_id FROM part_fts WHERE part_id='offline'`).get(),
+    ).toBeNull();
+
+    // Next ensureFts: triggers are missing, version still matches (no change),
+    // but triggersExist returns false so the entire index is rebuilt. After
+    // rebuild, the offline row should be present.
+    const r = ensureFts(db);
+    expect(r.built).toBe(true);
+
+    const offlineRow = db
+      .query<{ content: string }, []>(
+        `SELECT content FROM part_fts WHERE part_id='offline'`,
+      )
+      .get();
+    expect(offlineRow?.content).toBe("missed by triggers");
+    db.close();
+  });
+
+  test("incremental backfill does NOT double-index trigger-indexed rows (H1 regression)", () => {
+    const db = new Database(":memory:");
+    makeSchema(db);
+    ensureFts(db);
+
+    // Insert a row while triggers are alive. Trigger indexes it immediately
+    // (exactly 1 FTS row).
+    db.query(
+      `INSERT INTO part VALUES ('live','m1','s1',7000,7000,
+       '${JSON.stringify({ type: "text", text: "indexed by trigger" }).replace(/'/g, "''")}')`,
+    ).run();
+
+    const afterTrigger = db
+      .query<{ c: number }, []>(
+        `SELECT COUNT(*) c FROM part_fts WHERE part_id='live'`,
+      )
+      .get();
+    expect(afterTrigger?.c).toBe(1);
+
+    // Second ensureFts: maxPart > watermark, so the incremental backfill
+    // runs. Pre-H1-fix, this re-inserted the same row and the count became 2.
+    // Post-fix, the incremental DELETEs the rowid range first, so the count
+    // stays at 1.
+    const r = ensureFts(db);
+    expect(r.built).toBe(false);
+
+    const afterIncremental = db
+      .query<{ c: number }, []>(
+        `SELECT COUNT(*) c FROM part_fts WHERE part_id='live'`,
+      )
+      .get();
+    expect(afterIncremental?.c).toBe(1);
+
+    // Running ensureFts again on a quiescent DB is a true no-op (no DELETE,
+    // no INSERT, watermark already at MAX(rowid)).
+    const r2 = ensureFts(db);
+    expect(r2.built).toBe(false);
+    expect(r2.built_ms).toBeUndefined();
+
+    db.close();
+  });
+
+  test("watermark resets when part is truncated (rowid restarts) — M3", () => {
+    const db = new Database(":memory:");
+    makeSchema(db);
+    ensureFts(db);
+
+    const before = db
+      .query<{ value: string }, []>(
+        `SELECT value FROM part_fts_meta WHERE key='last_rowid'`,
+      )
+      .get();
+    const initialWatermark = Number(before?.value);
+    expect(initialWatermark).toBeGreaterThan(0);
+
+    // Simulate truncation: drop triggers (otherwise DELETE cascades to FTS
+    // and resets things naturally), wipe `part`. Manually set the watermark
+    // ahead of MAX(rowid) to mimic the post-truncate state where the meta
+    // table still holds the old watermark but the part table starts fresh.
+    db.exec(`DROP TRIGGER part_fts_ai`);
+    db.exec(`DROP TRIGGER part_fts_au`);
+    db.exec(`DROP TRIGGER part_fts_ad`);
+    db.query(`DELETE FROM part`).run();
+
+    // Re-install everything via a full rebuild (triggersExist=false branch).
+    ensureFts(db);
+
+    // Force the watermark forward to mimic a real-world truncate where
+    // part_fts_meta survived but MAX(rowid) restarted lower.
+    db.query(
+      `INSERT OR REPLACE INTO part_fts_meta(key, value) VALUES('last_rowid', ?)`,
+    ).run("99999");
+
+    // ensureFts sees maxPart (0) < watermark (99999) and should reset the
+    // watermark down, NOT silently skip future rows.
+    const r1 = ensureFts(db);
+    expect(r1.built).toBe(false);
+
+    const reset = db
+      .query<{ value: string }, []>(
+        `SELECT value FROM part_fts_meta WHERE key='last_rowid'`,
+      )
+      .get();
+    expect(Number(reset?.value)).toBe(0);
+
+    // Now insert a fresh row (rowid restarts at 1) and call ensureFts again.
+    db.query(
+      `INSERT INTO part VALUES ('p_after','m1','s1',8000,8000,
+       '${JSON.stringify({ type: "text", text: "after truncate" }).replace(/'/g, "''")}')`,
+    ).run();
+
+    const r2 = ensureFts(db);
+    expect(r2.built).toBe(false);
+
+    const found = db
+      .query<{ content: string }, []>(
+        `SELECT content FROM part_fts WHERE part_id='p_after'`,
+      )
+      .get();
+    expect(found?.content).toBe("after truncate");
+
+    db.close();
+  });
 });
 
 describe("rebuild atomicity", () => {
@@ -326,6 +582,90 @@ describe("rebuild atomicity", () => {
         | undefined
     )?.n;
     expect(after).toBe(before);
+
+    db.close();
+  });
+});
+
+describe("OpenCode schema drift defense", () => {
+  test("empty part table: no drift detected (does not trigger rebuild)", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL,
+        directory TEXT NOT NULL,
+        time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL
+      );
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE part (
+        id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+    `);
+    // Build once. The drift check should not fire (no rows to check).
+    const r1 = ensureFts(db);
+    expect(r1.built).toBe(true);
+    // Second call: still no drift, no rebuild.
+    const r2 = ensureFts(db);
+    expect(r2.built).toBe(false);
+    db.close();
+  });
+
+  test("normal schema: no drift detected", () => {
+    const db = new Database(":memory:");
+    makeSchema(db);
+    ensureFts(db);
+    // Second call should be incremental/no-op, NOT a forced rebuild.
+    const r = ensureFts(db);
+    expect(r.built).toBe(false);
+    db.close();
+  });
+
+  test("renamed key on text part: drift detected, FTS rebuilds", () => {
+    const db = new Database(":memory:");
+    makeSchema(db);
+    ensureFts(db);
+
+    // Capture original rebuild count via row content.
+    const initialRows = (
+      db.query<{ n: number }, []>(`SELECT COUNT(*) n FROM part_fts`).get() as
+        | { n: number }
+        | undefined
+    )?.n;
+    expect(initialRows).toBeGreaterThan(0);
+
+    // Simulate OpenCode renaming $.text -> $.content for text parts.
+    // Drop triggers first so the UPDATE doesn't try to maintain FTS.
+    db.exec(`DROP TRIGGER part_fts_ai`);
+    db.exec(`DROP TRIGGER part_fts_au`);
+    db.exec(`DROP TRIGGER part_fts_ad`);
+    // Replace the most recent text part's data with a drifted shape.
+    const drifted = JSON.stringify({
+      type: "text",
+      content: "renamed key, no longer $.text",
+    });
+    db.query(`UPDATE part SET data = ? WHERE id = 'p4'`).run(drifted);
+
+    // Capture warn calls so we can confirm we logged.
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (msg: string) => warnings.push(String(msg));
+
+    try {
+      const r = ensureFts(db);
+      // Drift detected, table dropped, rebuilt from scratch.
+      expect(r.built).toBe(true);
+      expect(
+        warnings.some((w) => w.includes("schema drift detected")),
+      ).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
 
     db.close();
   });

--- a/src/search/fts.test.ts
+++ b/src/search/fts.test.ts
@@ -1,0 +1,332 @@
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import {
+  ensureFts,
+  searchFts,
+  escapeFtsPhrase,
+  searchTitles,
+} from "./fts";
+
+/**
+ * In-memory integration tests for the FTS5 module. These tests build a
+ * miniature opencode schema, populate it with a handful of realistic rows,
+ * call ensureFts() to construct the index and triggers, then exercise the
+ * query and trigger paths directly. This is what would have caught the
+ * "searchKeywordFts is not defined" / "trigger crashes on malformed JSON"
+ * bugs the unit mocks let through.
+ */
+
+function makeSchema(db: Database): void {
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+
+  db.exec(`INSERT INTO session VALUES
+    ('s1','proj1','Storage layer work','/repo/a',1000,1500),
+    ('s2','proj1','Auth refactor','/repo/a',2000,2500),
+    ('s3','proj2','Other project',  '/repo/b',3000,3500);
+  `);
+
+  db.exec(`INSERT INTO message VALUES
+    ('m1','s1',1100,1100,'${JSON.stringify({ role: "user" }).replace(/'/g, "''")}'),
+    ('m2','s1',1200,1200,'${JSON.stringify({ role: "assistant" }).replace(/'/g, "''")}'),
+    ('m3','s2',2100,2100,'${JSON.stringify({ role: "user" }).replace(/'/g, "''")}');
+  `);
+
+  const ins = (id: string, mid: string, sid: string, t: number, data: object) =>
+    db
+      .query(`INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)`)
+      .run(id, mid, sid, t, t, JSON.stringify(data));
+
+  ins("p1", "m1", "s1", 1100, {
+    type: "text",
+    text: "How should I implement the storage layer for sessions?",
+  });
+  ins("p2", "m2", "s1", 1200, {
+    type: "tool",
+    tool: "edit",
+    state: { title: "Edit storage.ts", input: { filePath: "src/storage.ts" }, output: "ok" },
+  });
+  ins("p3", "m2", "s1", 1210, {
+    type: "patch",
+    files: ["src/storage.ts", "src/helpers.ts"],
+  });
+  ins("p4", "m3", "s2", 2100, {
+    type: "text",
+    text: "Switch to JWT for authentication tokens.",
+  });
+  // A non-searchable type — must be ignored by FTS without errors.
+  ins("p5", "m3", "s2", 2110, { type: "reasoning", text: "thinking..." });
+}
+
+describe("FTS5 module", () => {
+  let db: Database;
+
+  beforeAll(() => {
+    db = new Database(":memory:");
+    db.exec("PRAGMA journal_mode = MEMORY");
+    makeSchema(db);
+    const result = ensureFts(db);
+    expect(result.built).toBe(true);
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  test("backfill indexed all four part kinds", () => {
+    const counts = db
+      .query<{ kind: string; n: number }, []>(
+        `SELECT kind, COUNT(*) n FROM part_fts GROUP BY kind ORDER BY kind`,
+      )
+      .all();
+    const map = Object.fromEntries(counts.map((c) => [c.kind, c.n]));
+    expect(map.text).toBe(2);
+    expect(map.tool_name).toBe(1);
+    expect(map.tool_state).toBe(1);
+    // patch_file is flattened: 2 files in one patch part
+    expect(map.patch_file).toBe(2);
+  });
+
+  test("triggers and meta table created", () => {
+    const triggers = db
+      .query<{ name: string }, []>(
+        `SELECT name FROM sqlite_master WHERE type='trigger' AND name LIKE 'part_fts_%'`,
+      )
+      .all()
+      .map((r) => r.name)
+      .sort();
+    expect(triggers).toEqual(["part_fts_ad", "part_fts_ai", "part_fts_au"]);
+
+    const version = db
+      .query<{ value: string }, []>(
+        `SELECT value FROM part_fts_meta WHERE key='version'`,
+      )
+      .get()?.value;
+    expect(version).toBe("2");
+  });
+
+  test("ensureFts is idempotent (no rebuild on second call)", () => {
+    const r = ensureFts(db);
+    expect(r.built).toBe(false);
+  });
+
+  test("searchFts finds text matches", () => {
+    const hits = searchFts(db, escapeFtsPhrase("storage")!, {
+      projectID: null,
+      limit: 10,
+    });
+    const textHits = hits.filter((h) => h.kind === "text");
+    expect(textHits.length).toBeGreaterThan(0);
+  });
+
+  test("searchFts finds patch_file by individual file path", () => {
+    const hits = searchFts(db, escapeFtsPhrase("helpers.ts")!, {
+      projectID: null,
+      limit: 10,
+    });
+    const patchHits = hits.filter((h) => h.kind === "patch_file");
+    expect(patchHits.length).toBe(1);
+    expect(patchHits[0]?.content).toBe("src/helpers.ts");
+  });
+
+  test("searchFts respects projectID filter", () => {
+    const proj1 = searchFts(db, escapeFtsPhrase("storage")!, {
+      projectID: "proj1",
+      limit: 10,
+    });
+    const proj2 = searchFts(db, escapeFtsPhrase("storage")!, {
+      projectID: "proj2",
+      limit: 10,
+    });
+    expect(proj1.length).toBeGreaterThan(0);
+    expect(proj2.length).toBe(0);
+  });
+
+  test("searchFts respects role filter (pushed to SQL)", () => {
+    const userHits = searchFts(db, escapeFtsPhrase("storage")!, {
+      projectID: null,
+      role: "user",
+      limit: 10,
+    });
+    const assistantHits = searchFts(db, escapeFtsPhrase("storage")!, {
+      projectID: null,
+      role: "assistant",
+      limit: 10,
+    });
+    // 'storage' appears in m1 (user) and m2 (assistant patch + tool)
+    expect(userHits.length).toBeGreaterThan(0);
+    expect(assistantHits.length).toBeGreaterThan(0);
+    expect(userHits.every((h) => h.message_id === "m1")).toBe(true);
+  });
+
+  test("searchFts respects date range (pushed to SQL)", () => {
+    const old = searchFts(db, escapeFtsPhrase("authentication")!, {
+      projectID: null,
+      endTime: 1500,
+      limit: 10,
+    });
+    const newer = searchFts(db, escapeFtsPhrase("authentication")!, {
+      projectID: null,
+      startTime: 2000,
+      limit: 10,
+    });
+    expect(old.length).toBe(0); // p4 is at 2100, older than 1500 endTime
+    expect(newer.length).toBe(1);
+  });
+
+  test("searchTitles finds session by title", () => {
+    const hits = searchTitles(db, "Auth", { projectID: null, limit: 10 });
+    expect(hits.length).toBe(1);
+    expect(hits[0]?.id).toBe("s2");
+  });
+});
+
+describe("escapeFtsPhrase", () => {
+  test("wraps plain input in phrase quotes", () => {
+    expect(escapeFtsPhrase("hello world")).toBe('"hello world"');
+  });
+  test("doubles embedded quotes", () => {
+    expect(escapeFtsPhrase('say "hi"')).toBe('"say ""hi"""');
+  });
+  test("strips control characters", () => {
+    expect(escapeFtsPhrase("foo\u0000bar")).toBe('"foo bar"');
+    expect(escapeFtsPhrase("line1\nline2")).toBe('"line1 line2"');
+  });
+  test("returns null for empty / whitespace", () => {
+    expect(escapeFtsPhrase("")).toBe(null);
+    expect(escapeFtsPhrase("   ")).toBe(null);
+  });
+  test("returns null for all-punctuation input", () => {
+    expect(escapeFtsPhrase("???")).toBe(null);
+    expect(escapeFtsPhrase("!!!")).toBe(null);
+  });
+  test("accepts unicode letters", () => {
+    expect(escapeFtsPhrase("café")).toBe('"café"');
+    expect(escapeFtsPhrase("日本語")).toBe('"日本語"');
+  });
+});
+
+describe("triggers tolerate malformed part.data without breaking inserts", () => {
+  let db: Database;
+
+  beforeAll(() => {
+    db = new Database(":memory:");
+    makeSchema(db);
+    ensureFts(db);
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  test("INSERT of non-JSON data does NOT abort (json_valid guard works)", () => {
+    // This is THE failure mode the audit found: if the trigger ran
+    // json_extract on non-JSON, the parent INSERT would abort.
+    expect(() => {
+      db.query(
+        `INSERT INTO part VALUES ('bad1','m1','s1',9999,9999,'not json at all')`,
+      ).run();
+    }).not.toThrow();
+
+    // The row IS in part (parent insert succeeded)...
+    const row = db.query(`SELECT id FROM part WHERE id='bad1'`).get();
+    expect(row).toBeDefined();
+
+    // ...but NOT in part_fts (trigger silently skipped it)
+    const ftsRow = db
+      .query(`SELECT part_id FROM part_fts WHERE part_id='bad1'`)
+      .get();
+    expect(ftsRow).toBeNull();
+  });
+
+  test("UPDATE of malformed data does NOT abort", () => {
+    db.query(
+      `INSERT INTO part VALUES ('good1','m1','s1',8000,8000,'${JSON.stringify({ type: "text", text: "hello" }).replace(/'/g, "''")}')`,
+    ).run();
+    // The first insert worked, FTS has the row
+    let ftsRow = db
+      .query(`SELECT part_id FROM part_fts WHERE part_id='good1'`)
+      .get();
+    expect(ftsRow).toBeDefined();
+
+    // Now corrupt it
+    expect(() => {
+      db.query(`UPDATE part SET data='garbage' WHERE id='good1'`).run();
+    }).not.toThrow();
+
+    // FTS row should be deleted (DELETE trigger part runs) but no re-insert
+    ftsRow = db
+      .query(`SELECT part_id FROM part_fts WHERE part_id='good1'`)
+      .get();
+    expect(ftsRow).toBeNull();
+  });
+
+  test("DELETE removes FTS rows", () => {
+    db.query(
+      `INSERT INTO part VALUES ('del1','m1','s1',7000,7000,'${JSON.stringify({ type: "text", text: "doomed" }).replace(/'/g, "''")}')`,
+    ).run();
+    let ftsRow = db
+      .query(`SELECT part_id FROM part_fts WHERE part_id='del1'`)
+      .get();
+    expect(ftsRow).toBeDefined();
+
+    db.query(`DELETE FROM part WHERE id='del1'`).run();
+    ftsRow = db
+      .query(`SELECT part_id FROM part_fts WHERE part_id='del1'`)
+      .get();
+    expect(ftsRow).toBeNull();
+  });
+});
+
+describe("rebuild atomicity", () => {
+  test("ensureFts wraps build in a transaction; rollback leaves prior state", () => {
+    const db = new Database(":memory:");
+    makeSchema(db);
+    ensureFts(db);
+
+    const before = (
+      db.query<{ n: number }, []>(`SELECT COUNT(*) n FROM part_fts`).get() as
+        | { n: number }
+        | undefined
+    )?.n;
+    expect(before).toBeGreaterThan(0);
+
+    // Simulate a crash mid-build by manually beginning a transaction and
+    // rolling back. After rollback, the original index must still be intact.
+    db.exec("BEGIN IMMEDIATE");
+    db.exec("DROP TABLE part_fts");
+    db.exec("ROLLBACK");
+
+    const after = (
+      db.query<{ n: number }, []>(`SELECT COUNT(*) n FROM part_fts`).get() as
+        | { n: number }
+        | undefined
+    )?.n;
+    expect(after).toBe(before);
+
+    db.close();
+  });
+});

--- a/src/search/fts.ts
+++ b/src/search/fts.ts
@@ -48,15 +48,17 @@
  *     DROP TRIGGER IF EXISTS part_fts_au;
  *     DROP TRIGGER IF EXISTS part_fts_ad;
  *     DROP TABLE   IF EXISTS part_fts;
+ *     DROP TABLE   IF EXISTS part_fts_tri;
  *     DROP TABLE   IF EXISTS part_fts_meta;
  *   COMMIT;
- *   -- VACUUM;  -- optional, reclaims ~55 MB on a 3.9 GB DB
+ *   -- VACUUM;  -- optional, reclaims ~550 MB on a 3.9 GB DB
  */
 
 import { Database } from "bun:sqlite";
 import { getDbPath } from "../storage-sqlite";
 
 const FTS_TABLE = "part_fts";
+const TRI_TABLE = "part_fts_tri";
 // Bump when schema or trigger DDL changes. Forces a full rebuild on next
 // `ensureFts` so users with stale indexes get the fix without manual action.
 //   v1: initial single-text-only index (never shipped)
@@ -67,7 +69,11 @@ const FTS_TABLE = "part_fts";
 //       range before re-inserting, so rows already indexed by a live trigger
 //       don't end up duplicated. v3 indexes built between v3 ship and v4
 //       fix are 2x bloated; the version bump triggers a clean rebuild.
-const FTS_VERSION = 4;
+//   v5: trigram FTS5 table (part_fts_tri) for fuzzy mode. Indexes only text
+//       and tool_name content (tool_state JSON is too noisy + too big at
+//       ~232 MB; patch paths use exact match). Replaces the O(n) in-memory
+//       Fuse.js corpus rebuild that took 15+ seconds per fuzzy query.
+const FTS_VERSION = 5;
 
 // Busy timeout for the writable connection. Must comfortably exceed worst-case
 // rebuild time so OpenCode writes don't fail with SQLITE_BUSY while we're
@@ -231,9 +237,10 @@ export function ensureFts(db: Database): EnsureResult {
       `[history-search] OpenCode schema drift detected (${drift}). ` +
         `Forcing FTS rebuild; if search results look wrong, update this plugin.`,
     );
-    // Drop the FTS table so the fast-path check below fails and we fall
+    // Drop both FTS tables so the fast-path check below fails and we fall
     // through to the full rebuild branch.
     db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`);
+    db.exec(`DROP TABLE IF EXISTS ${TRI_TABLE}`);
   }
 
   const tableExists = db
@@ -267,8 +274,13 @@ export function ensureFts(db: Database): EnsureResult {
         // index 2x per cycle (and the JS-layer dedup hides this until search
         // returns half as many distinct results as it should). Wipe any
         // existing FTS rows for the range first so backfill is idempotent.
+        // Both tables (unicode61 + trigram).
         db.query(
           `DELETE FROM ${FTS_TABLE}
+           WHERE part_id IN (SELECT id FROM part WHERE rowid >= ?)`,
+        ).run(watermark + 1);
+        db.query(
+          `DELETE FROM ${TRI_TABLE}
            WHERE part_id IN (SELECT id FROM part WHERE rowid >= ?)`,
         ).run(watermark + 1);
         backfillRange(db, watermark + 1);
@@ -317,6 +329,20 @@ function buildFts(db: Database): void {
       tokenize = 'unicode61 remove_diacritics 2'
     );
   `);
+  // Trigram index for fuzzy/substring matches. Only indexes text and
+  // tool_name (tool_state is ~232 MB and too noisy for fuzzy; patch paths
+  // are matched exactly via the unicode61 index above).
+  db.exec(`DROP TABLE IF EXISTS ${TRI_TABLE}`);
+  db.exec(`
+    CREATE VIRTUAL TABLE ${TRI_TABLE} USING fts5(
+      content,
+      kind UNINDEXED,
+      part_id UNINDEXED,
+      message_id UNINDEXED,
+      session_id UNINDEXED,
+      tokenize = 'trigram'
+    );
+  `);
   backfillRange(db, 0);
 }
 
@@ -332,7 +358,8 @@ function buildFts(db: Database): void {
  *   error). Same guard mirrored in the triggers.
  */
 function backfillRange(db: Database, startRowid: number): void {
-  // Text parts
+  // Text parts — populate BOTH the unicode61 (keyword) and trigram (fuzzy)
+  // indexes from the same source rows.
   db.exec(`
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT json_extract(data, '$.text'), 'text', id, message_id, session_id
@@ -343,10 +370,33 @@ function backfillRange(db: Database, startRowid: number): void {
       AND json_extract(data, '$.text') IS NOT NULL
       AND json_extract(data, '$.text') != ''
   `);
+  db.exec(`
+    INSERT INTO ${TRI_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT json_extract(data, '$.text'), 'text', id, message_id, session_id
+    FROM part
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
+      AND json_extract(data, '$.type') = 'text'
+      AND json_extract(data, '$.text') IS NOT NULL
+      AND json_extract(data, '$.text') != ''
+  `);
 
-  // Tool name + state title (skip blanks)
+  // Tool name + state title (skip blanks) — also indexed in both for
+  // fuzzy "find that tool I half-remember".
   db.exec(`
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')),
+      'tool_name', id, message_id, session_id
+    FROM part
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
+      AND json_extract(data, '$.type') = 'tool'
+      AND json_extract(data, '$.tool') IS NOT NULL
+      AND trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')) != ''
+  `);
+  db.exec(`
+    INSERT INTO ${TRI_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT
       trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')),
       'tool_name', id, message_id, session_id
@@ -410,14 +460,25 @@ function backfillRange(db: Database, startRowid: number): void {
 const EXPECTED_TRIGGERS = ["part_fts_ai", "part_fts_ad", "part_fts_au"] as const;
 
 function insertFromPartSql(): string {
+  // Mirror every NEW row into both indexes. The trigram index gets text +
+  // tool_name only (smaller content for fuzzy); the unicode61 index gets
+  // all four kinds (keyword search has different needs).
   return `
+    -- text: both tables
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT json_extract(NEW.data, '$.text'), 'text', NEW.id, NEW.message_id, NEW.session_id
       WHERE json_valid(NEW.data)
         AND json_extract(NEW.data, '$.type') = 'text'
         AND json_extract(NEW.data, '$.text') IS NOT NULL
         AND json_extract(NEW.data, '$.text') != '';
+    INSERT INTO ${TRI_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT json_extract(NEW.data, '$.text'), 'text', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'text'
+        AND json_extract(NEW.data, '$.text') IS NOT NULL
+        AND json_extract(NEW.data, '$.text') != '';
 
+    -- tool_name: both tables
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT
       trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')),
@@ -426,7 +487,16 @@ function insertFromPartSql(): string {
         AND json_extract(NEW.data, '$.type') = 'tool'
         AND json_extract(NEW.data, '$.tool') IS NOT NULL
         AND trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')) != '';
+    INSERT INTO ${TRI_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')),
+      'tool_name', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'tool'
+        AND json_extract(NEW.data, '$.tool') IS NOT NULL
+        AND trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')) != '';
 
+    -- tool_state: unicode61 only (too big + too noisy for fuzzy)
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT
       trim(coalesce(json_extract(NEW.data, '$.state.input'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.output'), '')),
@@ -436,6 +506,7 @@ function insertFromPartSql(): string {
         AND json_extract(NEW.data, '$.state') IS NOT NULL
         AND trim(coalesce(json_extract(NEW.data, '$.state.input'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.output'), '')) != '';
 
+    -- patch_file: unicode61 only (exact path match, fuzzy doesn't help)
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT j.value, 'patch_file', NEW.id, NEW.message_id, NEW.session_id
       FROM json_each(
@@ -474,21 +545,24 @@ function installTriggers(db: Database): void {
     END;
   `);
 
-  // DELETE only reads OLD.id, so no json_valid guard needed.
+  // DELETE only reads OLD.id, so no json_valid guard needed. Clear both
+  // tables; either may have rows for this part.
   db.exec(`
     CREATE TRIGGER part_fts_ad AFTER DELETE ON part
     BEGIN
       DELETE FROM ${FTS_TABLE} WHERE part_id = OLD.id;
+      DELETE FROM ${TRI_TABLE} WHERE part_id = OLD.id;
     END;
   `);
 
   // UPDATE: delete-then-insert ensures correctness across type changes.
   // The DELETE uses OLD.id only (safe). The re-insert uses NEW.data, gated
-  // by json_valid + json_type='array' (safe).
+  // by json_valid + json_type='array' (safe). Both tables touched.
   db.exec(`
     CREATE TRIGGER part_fts_au AFTER UPDATE ON part
     BEGIN
       DELETE FROM ${FTS_TABLE} WHERE part_id = OLD.id;
+      DELETE FROM ${TRI_TABLE} WHERE part_id = OLD.id;
       ${insertFromPartSql()}
     END;
   `);
@@ -578,7 +652,37 @@ export function searchFts(
   query: string,
   opts: FtsQueryOptions,
 ): FtsHit[] {
-  const where: string[] = [`${FTS_TABLE}.content MATCH ?`];
+  return runFtsQuery(db, FTS_TABLE, query, opts);
+}
+
+/**
+ * Run an FTS5 MATCH query against the trigram index. Use this for
+ * substring-tolerant and typo-tolerant matching (fuzzy mode). The trigram
+ * index only covers `text` and `tool_name` kinds; tool_state and patch_file
+ * are not indexed there.
+ *
+ * Caller still wraps with `escapeFtsPhrase` so FTS5 treats input as a phrase.
+ */
+export function searchFtsTrigram(
+  db: Database,
+  query: string,
+  opts: FtsQueryOptions,
+): FtsHit[] {
+  return runFtsQuery(db, TRI_TABLE, query, opts);
+}
+
+// Constrain to the two module-private FTS table names so the only callers
+// of this helper are searchFts / searchFtsTrigram. Direct interpolation of
+// `table` into the SELECT is safe because the type prevents any other value.
+type FtsTable = typeof FTS_TABLE | typeof TRI_TABLE;
+
+function runFtsQuery(
+  db: Database,
+  table: FtsTable,
+  query: string,
+  opts: FtsQueryOptions,
+): FtsHit[] {
+  const where: string[] = [`${table}.content MATCH ?`];
   const binds: Bind[] = [query];
 
   if (opts.projectID) {
@@ -599,22 +703,20 @@ export function searchFts(
   }
   binds.push(opts.limit);
 
-  // No JOIN to `part`: the FTS row already contains the searchable content
-  // (text body, file path, tool name, etc.). Pulling 16KB+ data blobs over
-  // the FFI just to re-decode them in JS was the slow path.
+  // No JOIN to `part`: the FTS row already contains the searchable content.
   const sql = `
     SELECT
-      ${FTS_TABLE}.part_id    AS part_id,
-      ${FTS_TABLE}.message_id AS message_id,
-      ${FTS_TABLE}.session_id AS session_id,
-      ${FTS_TABLE}.content    AS content,
-      ${FTS_TABLE}.kind       AS kind,
-      m.time_created          AS time_created,
-      s.title                 AS session_title,
-      s.directory             AS session_directory
-    FROM ${FTS_TABLE}
-    JOIN message m ON m.id = ${FTS_TABLE}.message_id
-    JOIN session s ON s.id = ${FTS_TABLE}.session_id
+      ${table}.part_id    AS part_id,
+      ${table}.message_id AS message_id,
+      ${table}.session_id AS session_id,
+      ${table}.content    AS content,
+      ${table}.kind       AS kind,
+      m.time_created      AS time_created,
+      s.title             AS session_title,
+      s.directory         AS session_directory
+    FROM ${table}
+    JOIN message m ON m.id = ${table}.message_id
+    JOIN session s ON s.id = ${table}.session_id
     WHERE ${where.join(" AND ")}
     ORDER BY m.time_created DESC
     LIMIT ?
@@ -626,7 +728,7 @@ export function searchFts(
     if (!warnedQueryError) {
       warnedQueryError = true;
       const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[history-search] FTS query failed: ${message}`);
+      console.warn(`[history-search] FTS query failed (${table}): ${message}`);
     }
     return [];
   }

--- a/src/search/fts.ts
+++ b/src/search/fts.ts
@@ -14,36 +14,70 @@
  * One row per searchable extracted piece of content from a part:
  *   - text parts:    one row (the message text)
  *   - tool parts:    up to two rows (tool name + state input/output blob)
- *   - patch parts:   one row PER file path (json_each flattening)
+ *   - patch parts:   one row PER file path (json_each flattening, guarded
+ *                    so a non-array $.files cannot abort OpenCode's INSERT)
  *
  * Triggers keep the index in sync on insert/update/delete of `part` rows.
- * EVERY trigger that reads `data` is guarded with `json_valid(...)` so a
- * future code path writing non-JSON `part.data` (truncated stream, binary,
- * schema change) CANNOT break OpenCode's primary insert path.
+ * EVERY trigger that reads `data` is guarded against malformed JSON in two
+ * ways:
+ *   1. `json_valid(NEW.data)` in the WHERE clause for `json_extract` callers.
+ *   2. `json_each` is fed a `CASE WHEN json_type(...,'$.files')='array' THEN
+ *      ... ELSE '[]' END` so a non-array `$.files` never reaches `json_each`
+ *      (which throws `malformed JSON` and aborts the parent INSERT).
+ *
+ * Together these guarantee a future code path writing non-JSON or non-array
+ * `part.data` (truncated stream, binary, schema change) CANNOT break
+ * OpenCode's primary insert path.
  *
  * Idempotency:
- *   - `ensureFts(db)` is safe to call on every search. It's a metadata check
- *     plus a row-count comparison, ~microseconds when the index is up to date.
+ *   - `ensureFts(db)` is safe to call on every search. Fast path is a
+ *     metadata check plus a rowid watermark comparison.
  *   - First call builds the index (~3 sec for 200k parts).
+ *   - Subsequent calls do an incremental backfill of any part rows whose
+ *     rowid is greater than the last-indexed watermark stored in
+ *     `part_fts_meta`. This catches rows that older trigger versions skipped
+ *     or that were inserted while this plugin wasn't loaded.
  *   - If the version metadata mismatches, the index is rebuilt from scratch
  *     INSIDE a single transaction so a crash mid-build leaves the old index
  *     intact.
  *
  * Rollback (run manually if uninstalling):
+ *   PRAGMA busy_timeout = 15000;
  *   BEGIN IMMEDIATE;
- *   DROP TRIGGER IF EXISTS part_fts_ai;
- *   DROP TRIGGER IF EXISTS part_fts_au;
- *   DROP TRIGGER IF EXISTS part_fts_ad;
- *   DROP TABLE   IF EXISTS part_fts;
- *   DROP TABLE   IF EXISTS part_fts_meta;
+ *     DROP TRIGGER IF EXISTS part_fts_ai;
+ *     DROP TRIGGER IF EXISTS part_fts_au;
+ *     DROP TRIGGER IF EXISTS part_fts_ad;
+ *     DROP TABLE   IF EXISTS part_fts;
+ *     DROP TABLE   IF EXISTS part_fts_meta;
  *   COMMIT;
+ *   -- VACUUM;  -- optional, reclaims ~55 MB on a 3.9 GB DB
  */
 
 import { Database } from "bun:sqlite";
 import { getDbPath } from "../storage-sqlite";
 
 const FTS_TABLE = "part_fts";
-const FTS_VERSION = 2; // bump if schema changes and a rebuild is required
+// Bump when schema or trigger DDL changes. Forces a full rebuild on next
+// `ensureFts` so users with stale indexes get the fix without manual action.
+//   v1: initial single-text-only index (never shipped)
+//   v2: text + tool_name + tool_state + patch_file (as JSON array text)
+//   v3: patch_file flattened via json_each + CASE guard against non-array
+//       $.files (F1 fix); also adds rowid watermark for incremental backfill
+//   v4: H1 fix — incremental backfill DELETEs any existing FTS rows for the
+//       range before re-inserting, so rows already indexed by a live trigger
+//       don't end up duplicated. v3 indexes built between v3 ship and v4
+//       fix are 2x bloated; the version bump triggers a clean rebuild.
+const FTS_VERSION = 4;
+
+// Busy timeout for the writable connection. Must comfortably exceed worst-case
+// rebuild time so OpenCode writes don't fail with SQLITE_BUSY while we're
+// rebuilding. Backfill at 200k parts is ~3s; 15s gives ~5x headroom.
+const BUSY_TIMEOUT_MS = 15000;
+
+// Retry an `ensureFtsOnce` failure after this long. Distinguishes transient
+// failures (SQLITE_BUSY, SQLITE_LOCKED) from permanent ones (FTS5 not
+// compiled, disk full, schema mismatch). For permanents we never retry.
+const TRANSIENT_RETRY_MS = 60_000;
 
 export type FtsKind = "text" | "tool_name" | "tool_state" | "patch_file";
 
@@ -55,60 +89,198 @@ export interface EnsureResult {
   built: boolean;
   built_ms?: number;
   error?: string;
+  /** True if the error is transient (lock contention) and worth retrying. */
+  transient?: boolean;
 }
 
-// Module-level latch: intentionally not reset for the lifetime of the process.
-// We set this to `true` on BOTH success and failure to avoid a hot-loop where
-// every subsequent search re-opens a writable connection. A failure is
-// reported once via the EnsureResult and then we trust the next process
-// startup to retry. This matches "ensure once" semantics.
-let ensured = false;
+// Module-level latch. For PERMANENT failures we set this once and never
+// retry — matches "ensure once" semantics. For TRANSIENT failures (lock
+// contention against an active OpenCode writer) we allow one retry every
+// TRANSIENT_RETRY_MS so a brief busy window doesn't degrade search for the
+// rest of the process lifetime.
+let ensuredAt: number | null = null;
+let permanentFailure = false;
+
+function isTransientSqliteError(err: unknown): boolean {
+  // Prefer the structured error code over the localized message string.
+  // bun:sqlite exposes `code` on SqliteError instances.
+  const code = (err as { code?: string } | undefined)?.code;
+  if (
+    code === "SQLITE_BUSY" ||
+    code === "SQLITE_LOCKED" ||
+    code === "SQLITE_PROTOCOL"
+  ) {
+    return true;
+  }
+  // Fallback: not every transient surfaces here as an SqliteError; some throws
+  // are bare Error instances. Match the message as a backstop.
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    message.includes("database is locked") ||
+    message.includes("database table is locked") ||
+    message.includes("sqlite_busy") ||
+    message.includes("sqlite_locked")
+  );
+}
 
 export function ensureFtsOnce(): EnsureResult {
-  if (ensured) return { built: false };
-  ensured = true; // latch first so any throw below doesn't cause retry storm
+  // Permanent failures: never retry.
+  if (permanentFailure) return { built: false, error: "fts-permanently-disabled" };
+  // Successful or recent-transient: short-circuit.
+  if (ensuredAt !== null && Date.now() - ensuredAt < TRANSIENT_RETRY_MS) {
+    return { built: false };
+  }
+
   let db: Database | undefined;
   try {
     db = new Database(getDbPath()); // writable
     // Wait politely for any concurrent OpenCode writer instead of failing
     // immediately with SQLITE_BUSY. bun:sqlite default is 0ms.
-    db.exec("PRAGMA busy_timeout = 5000");
-    return ensureFts(db);
+    db.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    const result = ensureFts(db);
+    ensuredAt = Date.now();
+    return result;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    return { built: false, error: message };
+    const transient = isTransientSqliteError(err);
+    if (transient) {
+      // Allow another attempt after TRANSIENT_RETRY_MS. Set ensuredAt so we
+      // don't hot-loop on every search, but don't latch permanently.
+      ensuredAt = Date.now();
+    } else {
+      permanentFailure = true;
+    }
+    return { built: false, error: message, transient };
   } finally {
     db?.close();
   }
 }
 
 /**
+ * Cheap sanity check that OpenCode hasn't changed `part.data`'s JSON shape
+ * out from under us. Samples the most recent row of each type we care about
+ * (text/tool/patch) and verifies the JSON keys we depend on still exist.
+ *
+ * Returns null if everything looks normal (or if the table is empty).
+ * Returns a short reason string if drift is detected.
+ *
+ * This is NOT a guarantee of correctness — OpenCode could change a value's
+ * type without changing key presence, and we'd miss it. But it catches the
+ * common cases (renamed keys, dropped fields, format swap) early enough to
+ * surface a warning instead of silently degrading search.
+ */
+function detectSchemaDrift(db: Database): string | null {
+  type Row = { data: string };
+
+  // For each type we index, grab the most recent row. If none exist, that
+  // type is just empty — not drift. If one exists but is missing required
+  // keys, that's drift.
+  const samples: Array<{ type: string; required: string[] }> = [
+    { type: "text", required: ["$.text"] },
+    { type: "tool", required: ["$.tool"] },
+    { type: "patch", required: ["$.files"] },
+  ];
+
+  for (const { type, required } of samples) {
+    const row = db
+      .query<Row, string>(
+        `SELECT data FROM part
+         WHERE json_valid(data) AND json_extract(data, '$.type') = ?
+         ORDER BY rowid DESC LIMIT 1`,
+      )
+      .get(type);
+    if (!row) continue;
+    for (const key of required) {
+      // json_type returns NULL if the path doesn't exist. If a future
+      // OpenCode version renames the key, this catches it.
+      const present = (db
+        .query<{ t: string | null }, [string, string]>(
+          `SELECT json_type(?, ?) AS t`,
+        )
+        .get(row.data, key))?.t;
+      if (present === null || present === undefined) {
+        return `part type='${type}' missing expected key '${key}'`;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Inspect existing state and rebuild only if necessary. The rebuild path is
  * fully transactional: a crash mid-build rolls back and leaves the old index
  * (or no index) intact.
+ *
+ * The fast path uses a rowid watermark stored in `part_fts_meta`. On every
+ * call we check whether any part rows have been inserted past the watermark
+ * and incrementally backfill them. This catches rows that older trigger
+ * versions skipped or that were inserted while this plugin wasn't loaded.
  */
 export function ensureFts(db: Database): EnsureResult {
+  ensureMetaTable(db);
+
+  // Defense against OpenCode schema drift on upgrade. If they ever change
+  // the shape of part.data (rename $.text, switch to msgpack, etc.) our
+  // triggers won't crash thanks to json_valid, but search results would go
+  // silently stale. This check catches that early and forces a rebuild
+  // (which won't help if the shape really changed, but it will surface the
+  // problem loudly via the warn instead of silently degrading).
+  const drift = detectSchemaDrift(db);
+  if (drift) {
+    console.warn(
+      `[history-search] OpenCode schema drift detected (${drift}). ` +
+        `Forcing FTS rebuild; if search results look wrong, update this plugin.`,
+    );
+    // Drop the FTS table so the fast-path check below fails and we fall
+    // through to the full rebuild branch.
+    db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`);
+  }
+
   const tableExists = db
     .query(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
     .get(FTS_TABLE);
 
   if (tableExists && triggersExist(db) && versionMatches(db)) {
-    // Conservative drift check. We'd rather skip a rebuild than do one
-    // needlessly: false-negative = slightly stale results until the next
-    // version bump; false-positive = unnecessary 3-second rebuild.
-    const expected = (db
-      .query(
-        `SELECT COUNT(*) c FROM part
-         WHERE json_valid(data)
-           AND json_extract(data, '$.type') IN ('text','tool','patch')`,
-      )
-      .get() as { c: number }).c;
-    const actual = (db
-      .query(`SELECT COUNT(DISTINCT part_id) c FROM ${FTS_TABLE}`)
-      .get() as { c: number }).c;
-    if (actual >= expected * 0.95) {
+    // Incremental backfill: index any part rows whose rowid is past the
+    // watermark we recorded at last successful backfill. This is the
+    // authoritative drift check — strictly correct, no fudge factor.
+    const watermark = readWatermark(db);
+    const maxPart = (db
+      .query(`SELECT COALESCE(MAX(rowid), 0) AS r FROM part`)
+      .get() as { r: number }).r;
+
+    // M3: if `part` was truncated externally, rowid restarts at 1 and the
+    // stored watermark is now in the future. Reset so we don't permanently
+    // skip the first `watermark` rows of the new generation.
+    if (maxPart < watermark) {
+      writeWatermark(db, maxPart);
       return { built: false };
     }
+
+    if (maxPart > watermark) {
+      const t0 = performance.now();
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        // CRITICAL (H1): when triggers are live, every row inserted past the
+        // watermark has already been indexed by `part_fts_ai`. If we just
+        // re-run backfillRange we'd double-index every such row, growing the
+        // index 2x per cycle (and the JS-layer dedup hides this until search
+        // returns half as many distinct results as it should). Wipe any
+        // existing FTS rows for the range first so backfill is idempotent.
+        db.query(
+          `DELETE FROM ${FTS_TABLE}
+           WHERE part_id IN (SELECT id FROM part WHERE rowid >= ?)`,
+        ).run(watermark + 1);
+        backfillRange(db, watermark + 1);
+        writeWatermark(db, maxPart);
+        db.exec("COMMIT");
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+      return { built: false, built_ms: performance.now() - t0 };
+    }
+    return { built: false };
   }
 
   const t0 = performance.now();
@@ -116,6 +288,10 @@ export function ensureFts(db: Database): EnsureResult {
   try {
     buildFts(db);
     installTriggers(db);
+    const maxPart = (db
+      .query(`SELECT COALESCE(MAX(rowid), 0) AS r FROM part`)
+      .get() as { r: number }).r;
+    writeWatermark(db, maxPart);
     recordVersion(db);
     db.exec("COMMIT");
   } catch (err) {
@@ -126,7 +302,7 @@ export function ensureFts(db: Database): EnsureResult {
 }
 
 // ---------------------------------------------------------------------------
-// Backfill
+// Backfill (full + incremental share the same WHERE shape)
 // ---------------------------------------------------------------------------
 
 function buildFts(db: Database): void {
@@ -141,13 +317,28 @@ function buildFts(db: Database): void {
       tokenize = 'unicode61 remove_diacritics 2'
     );
   `);
+  backfillRange(db, 0);
+}
 
+/**
+ * Index part rows whose rowid is >= `startRowid`. Used by both the full
+ * build (startRowid=0) and the incremental top-up (startRowid=watermark+1).
+ *
+ * Note on patch_file:
+ *   `json_each` aborts with `malformed JSON` if its argument isn't an array
+ *   or NULL. A patch row with `files: "string"` would kill the backfill.
+ *   We use `CASE WHEN json_type(...,'$.files')='array' THEN ... ELSE '[]'
+ *   END` so non-array values become an empty array (zero FTS rows, no
+ *   error). Same guard mirrored in the triggers.
+ */
+function backfillRange(db: Database, startRowid: number): void {
   // Text parts
   db.exec(`
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT json_extract(data, '$.text'), 'text', id, message_id, session_id
     FROM part
-    WHERE json_valid(data)
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
       AND json_extract(data, '$.type') = 'text'
       AND json_extract(data, '$.text') IS NOT NULL
       AND json_extract(data, '$.text') != ''
@@ -160,7 +351,8 @@ function buildFts(db: Database): void {
       trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')),
       'tool_name', id, message_id, session_id
     FROM part
-    WHERE json_valid(data)
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
       AND json_extract(data, '$.type') = 'tool'
       AND json_extract(data, '$.tool') IS NOT NULL
       AND trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')) != ''
@@ -173,21 +365,30 @@ function buildFts(db: Database): void {
       trim(coalesce(json_extract(data, '$.state.input'), '') || ' ' || coalesce(json_extract(data, '$.state.output'), '')),
       'tool_state', id, message_id, session_id
     FROM part
-    WHERE json_valid(data)
+    WHERE rowid >= ${startRowid}
+      AND json_valid(data)
       AND json_extract(data, '$.type') = 'tool'
       AND json_extract(data, '$.state') IS NOT NULL
       AND trim(coalesce(json_extract(data, '$.state.input'), '') || ' ' || coalesce(json_extract(data, '$.state.output'), '')) != ''
   `);
 
-  // Patch files, flattened: one FTS row per file path (NOT the JSON array text)
+  // Patch files, flattened: one FTS row per file path. We pre-filter to
+  // valid patch rows with array-typed $.files in a subquery so json_each
+  // never sees a row it would crash on. The CASE wrapper is the F1 audit
+  // fix — without it, a patch row with non-array $.files would abort
+  // OpenCode's INSERT through the trigger.
   db.exec(`
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT j.value, 'patch_file', p.id, p.message_id, p.session_id
-    FROM part p, json_each(json_extract(p.data, '$.files')) j
-    WHERE json_valid(p.data)
-      AND json_extract(p.data, '$.type') = 'patch'
-      AND json_extract(p.data, '$.files') IS NOT NULL
-      AND j.value IS NOT NULL
+    FROM (
+      SELECT id, message_id, session_id, json_extract(data, '$.files') AS files
+      FROM part
+      WHERE rowid >= ${startRowid}
+        AND json_valid(data)
+        AND json_extract(data, '$.type') = 'patch'
+        AND json_type(data, '$.files') = 'array'
+    ) p, json_each(p.files) j
+    WHERE j.value IS NOT NULL
       AND j.value != ''
   `);
 }
@@ -196,70 +397,80 @@ function buildFts(db: Database): void {
 // Triggers
 //
 // Helpers below build the per-kind INSERTs as strings parameterized on the
-// row alias (NEW for INSERT, NEW for the re-insert side of UPDATE). The
-// CRITICAL property of every body is: json_valid(<alias>.data) gate FIRST.
-// Without this, a single malformed `part.data` write anywhere in OpenCode
+// row alias (always NEW). The CRITICAL property of every body:
+//   - json_valid(NEW.data) gates every json_extract caller (F1's textual
+//     siblings)
+//   - json_each is wrapped in a CASE WHEN json_type(...,'$.files')='array'
+//     so a non-array $.files never reaches json_each (F1 fix)
+// Without these, a single malformed `part.data` write anywhere in OpenCode
 // would propagate `malformed JSON` up through the trigger and abort the
 // host INSERT, breaking OpenCode itself.
 // ---------------------------------------------------------------------------
 
-function insertFromPartSql(alias: "NEW"): string {
+const EXPECTED_TRIGGERS = ["part_fts_ai", "part_fts_ad", "part_fts_au"] as const;
+
+function insertFromPartSql(): string {
   return `
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
-    SELECT json_extract(${alias}.data, '$.text'), 'text', ${alias}.id, ${alias}.message_id, ${alias}.session_id
-      WHERE json_valid(${alias}.data)
-        AND json_extract(${alias}.data, '$.type') = 'text'
-        AND json_extract(${alias}.data, '$.text') IS NOT NULL
-        AND json_extract(${alias}.data, '$.text') != '';
+    SELECT json_extract(NEW.data, '$.text'), 'text', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'text'
+        AND json_extract(NEW.data, '$.text') IS NOT NULL
+        AND json_extract(NEW.data, '$.text') != '';
 
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT
-      trim(coalesce(json_extract(${alias}.data, '$.tool'), '') || ' ' || coalesce(json_extract(${alias}.data, '$.state.title'), '')),
-      'tool_name', ${alias}.id, ${alias}.message_id, ${alias}.session_id
-      WHERE json_valid(${alias}.data)
-        AND json_extract(${alias}.data, '$.type') = 'tool'
-        AND json_extract(${alias}.data, '$.tool') IS NOT NULL
-        AND trim(coalesce(json_extract(${alias}.data, '$.tool'), '') || ' ' || coalesce(json_extract(${alias}.data, '$.state.title'), '')) != '';
+      trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')),
+      'tool_name', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'tool'
+        AND json_extract(NEW.data, '$.tool') IS NOT NULL
+        AND trim(coalesce(json_extract(NEW.data, '$.tool'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.title'), '')) != '';
 
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
     SELECT
-      trim(coalesce(json_extract(${alias}.data, '$.state.input'), '') || ' ' || coalesce(json_extract(${alias}.data, '$.state.output'), '')),
-      'tool_state', ${alias}.id, ${alias}.message_id, ${alias}.session_id
-      WHERE json_valid(${alias}.data)
-        AND json_extract(${alias}.data, '$.type') = 'tool'
-        AND json_extract(${alias}.data, '$.state') IS NOT NULL
-        AND trim(coalesce(json_extract(${alias}.data, '$.state.input'), '') || ' ' || coalesce(json_extract(${alias}.data, '$.state.output'), '')) != '';
+      trim(coalesce(json_extract(NEW.data, '$.state.input'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.output'), '')),
+      'tool_state', NEW.id, NEW.message_id, NEW.session_id
+      WHERE json_valid(NEW.data)
+        AND json_extract(NEW.data, '$.type') = 'tool'
+        AND json_extract(NEW.data, '$.state') IS NOT NULL
+        AND trim(coalesce(json_extract(NEW.data, '$.state.input'), '') || ' ' || coalesce(json_extract(NEW.data, '$.state.output'), '')) != '';
 
     INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
-    SELECT j.value, 'patch_file', ${alias}.id, ${alias}.message_id, ${alias}.session_id
-      FROM json_each(json_extract(${alias}.data, '$.files')) j
-      WHERE json_valid(${alias}.data)
-        AND json_extract(${alias}.data, '$.type') = 'patch'
-        AND json_extract(${alias}.data, '$.files') IS NOT NULL
-        AND j.value IS NOT NULL
+    SELECT j.value, 'patch_file', NEW.id, NEW.message_id, NEW.session_id
+      FROM json_each(
+        CASE
+          WHEN json_valid(NEW.data)
+           AND json_extract(NEW.data, '$.type') = 'patch'
+           AND json_type(NEW.data, '$.files') = 'array'
+          THEN json_extract(NEW.data, '$.files')
+          ELSE '[]'
+        END
+      ) j
+      WHERE j.value IS NOT NULL
         AND j.value != '';
   `;
 }
 
 function triggersExist(db: Database): boolean {
-  const triggers = db
-    .query(
-      `SELECT name FROM sqlite_master
-       WHERE type='trigger' AND name IN ('part_fts_ai', 'part_fts_ad', 'part_fts_au')`,
+  const placeholders = EXPECTED_TRIGGERS.map(() => "?").join(",");
+  const rows = db
+    .query<{ name: string }, string[]>(
+      `SELECT name FROM sqlite_master WHERE type='trigger' AND name IN (${placeholders})`,
     )
-    .all() as Array<{ name: string }>;
-  return triggers.length === 3;
+    .all(...EXPECTED_TRIGGERS);
+  return rows.length === EXPECTED_TRIGGERS.length;
 }
 
 function installTriggers(db: Database): void {
-  db.exec(`DROP TRIGGER IF EXISTS part_fts_ai`);
-  db.exec(`DROP TRIGGER IF EXISTS part_fts_ad`);
-  db.exec(`DROP TRIGGER IF EXISTS part_fts_au`);
+  for (const name of EXPECTED_TRIGGERS) {
+    db.exec(`DROP TRIGGER IF EXISTS ${name}`);
+  }
 
   db.exec(`
     CREATE TRIGGER part_fts_ai AFTER INSERT ON part
     BEGIN
-      ${insertFromPartSql("NEW")}
+      ${insertFromPartSql()}
     END;
   `);
 
@@ -273,27 +484,30 @@ function installTriggers(db: Database): void {
 
   // UPDATE: delete-then-insert ensures correctness across type changes.
   // The DELETE uses OLD.id only (safe). The re-insert uses NEW.data, gated
-  // by json_valid (safe).
+  // by json_valid + json_type='array' (safe).
   db.exec(`
     CREATE TRIGGER part_fts_au AFTER UPDATE ON part
     BEGIN
       DELETE FROM ${FTS_TABLE} WHERE part_id = OLD.id;
-      ${insertFromPartSql("NEW")}
+      ${insertFromPartSql()}
     END;
   `);
 }
 
 // ---------------------------------------------------------------------------
-// Version metadata
+// Version + watermark metadata
 // ---------------------------------------------------------------------------
 
-function versionMatches(db: Database): boolean {
-  // This is called only from `ensureFts`, which is only invoked through
-  // `ensureFtsOnce` on a WRITABLE connection. If anyone ever calls this on a
-  // read-only handle, we want to know about it, so no try/catch here.
+function ensureMetaTable(db: Database): void {
+  // Called only on the writable connection in `ensureFtsOnce`. Read-only
+  // callers will throw SQLITE_READONLY here, which is the intended failure
+  // mode (we want it loud, not silent).
   db.exec(
     `CREATE TABLE IF NOT EXISTS part_fts_meta (key TEXT PRIMARY KEY, value TEXT)`,
   );
+}
+
+function versionMatches(db: Database): boolean {
   const row = db
     .query(`SELECT value FROM part_fts_meta WHERE key = 'version'`)
     .get() as { value: string } | undefined;
@@ -301,12 +515,22 @@ function versionMatches(db: Database): boolean {
 }
 
 function recordVersion(db: Database): void {
-  db.exec(
-    `CREATE TABLE IF NOT EXISTS part_fts_meta (key TEXT PRIMARY KEY, value TEXT)`,
-  );
   db.query(
     `INSERT OR REPLACE INTO part_fts_meta(key, value) VALUES('version', ?)`,
   ).run(String(FTS_VERSION));
+}
+
+function readWatermark(db: Database): number {
+  const row = db
+    .query(`SELECT value FROM part_fts_meta WHERE key = 'last_rowid'`)
+    .get() as { value: string } | undefined;
+  return row ? Number(row.value) : 0;
+}
+
+function writeWatermark(db: Database, rowid: number): void {
+  db.query(
+    `INSERT OR REPLACE INTO part_fts_meta(key, value) VALUES('last_rowid', ?)`,
+  ).run(String(rowid));
 }
 
 // ---------------------------------------------------------------------------
@@ -333,6 +557,11 @@ export interface FtsQueryOptions {
 }
 
 type Bind = string | number | bigint | null;
+
+// One-time warn latch for searchFts errors. FTS5 syntax errors shouldn't
+// crash the host, but we also don't want to spam logs if a malformed query
+// comes through repeatedly.
+let warnedQueryError = false;
 
 /**
  * Run an FTS5 MATCH query against indexed part content, joined back to
@@ -394,10 +623,11 @@ export function searchFts(
   try {
     return db.query(sql).all(...binds) as FtsHit[];
   } catch (err: unknown) {
-    // FTS5 syntax errors should never crash the host. Log once and return
-    // an empty result so the caller can fall back gracefully if it wants.
-    const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[history-search] FTS query failed: ${message}`);
+    if (!warnedQueryError) {
+      warnedQueryError = true;
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[history-search] FTS query failed: ${message}`);
+    }
     return [];
   }
 }
@@ -412,14 +642,25 @@ export function searchFts(
  * inside the FTS5 parser).
  */
 export function escapeFtsPhrase(s: string): string | null {
-  // Strip ASCII control characters (incl. NUL, newlines, tabs). FTS5 treats
-  // whitespace as a token boundary anyway, so replacing with space is safe.
+  const cleaned = sanitizeQuery(s);
+  if (cleaned === null) return null;
+  return `"${cleaned.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Strip ASCII control characters (incl. NUL, newlines, tabs) and trim
+ * whitespace. Returns null if the input has no tokenizable content
+ * (empty, whitespace-only, all-punctuation). Shared by FTS phrase escape
+ * and LIKE-based title search so both paths sanitize identically.
+ */
+export function sanitizeQuery(s: string): string | null {
   const cleaned = s.replace(/[\u0000-\u001f]/g, " ").trim();
   if (cleaned === "") return null;
   // Require at least one alphanumeric or unicode-letter character; FTS5
   // tokenizes punctuation away and would receive zero tokens otherwise.
+  // Also keeps LIKE searches from returning the entire table on '%' input.
   if (!/[\p{L}\p{N}]/u.test(cleaned)) return null;
-  return `"${cleaned.replace(/"/g, '""')}"`;
+  return cleaned;
 }
 
 // ---------------------------------------------------------------------------
@@ -433,12 +674,26 @@ export interface TitleHit {
   time_updated: number;
 }
 
+/**
+ * Return session-title hits for `query` via LIKE on session.title.
+ *
+ * Returns `[]` when `query` has no tokenizable content (empty, whitespace,
+ * all-punctuation). This matches `escapeFtsPhrase`'s null-return contract
+ * and prevents a stray `LIKE '%%'` from scanning every session. Callers
+ * that need fallback semantics for non-tokenizable input should detect the
+ * empty array and route to the row-scan path themselves.
+ */
 export function searchTitles(
   db: Database,
   query: string,
   opts: { projectID: string | null; limit: number },
 ): TitleHit[] {
-  const like = `%${query.replace(/[\\%_]/g, (c) => "\\" + c)}%`;
+  // Share the sanitize step with the FTS path so control chars and
+  // pathological inputs can't slip through here.
+  const cleaned = sanitizeQuery(query);
+  if (cleaned === null) return [];
+
+  const like = `%${cleaned.replace(/[\\%_]/g, (c) => "\\" + c)}%`;
   const sql = `
     SELECT id, title, directory, time_updated
     FROM session

--- a/src/search/fts.ts
+++ b/src/search/fts.ts
@@ -1,0 +1,454 @@
+/**
+ * SQLite FTS5 full-text index over part content.
+ *
+ * Schema:
+ *   CREATE VIRTUAL TABLE part_fts USING fts5(
+ *     content,             -- the searchable text
+ *     kind        UNINDEXED, -- 'text' | 'tool_name' | 'tool_state' | 'patch_file'
+ *     part_id     UNINDEXED,
+ *     message_id  UNINDEXED,
+ *     session_id  UNINDEXED,
+ *     tokenize = 'unicode61 remove_diacritics 2'
+ *   );
+ *
+ * One row per searchable extracted piece of content from a part:
+ *   - text parts:    one row (the message text)
+ *   - tool parts:    up to two rows (tool name + state input/output blob)
+ *   - patch parts:   one row PER file path (json_each flattening)
+ *
+ * Triggers keep the index in sync on insert/update/delete of `part` rows.
+ * EVERY trigger that reads `data` is guarded with `json_valid(...)` so a
+ * future code path writing non-JSON `part.data` (truncated stream, binary,
+ * schema change) CANNOT break OpenCode's primary insert path.
+ *
+ * Idempotency:
+ *   - `ensureFts(db)` is safe to call on every search. It's a metadata check
+ *     plus a row-count comparison, ~microseconds when the index is up to date.
+ *   - First call builds the index (~3 sec for 200k parts).
+ *   - If the version metadata mismatches, the index is rebuilt from scratch
+ *     INSIDE a single transaction so a crash mid-build leaves the old index
+ *     intact.
+ *
+ * Rollback (run manually if uninstalling):
+ *   BEGIN IMMEDIATE;
+ *   DROP TRIGGER IF EXISTS part_fts_ai;
+ *   DROP TRIGGER IF EXISTS part_fts_au;
+ *   DROP TRIGGER IF EXISTS part_fts_ad;
+ *   DROP TABLE   IF EXISTS part_fts;
+ *   DROP TABLE   IF EXISTS part_fts_meta;
+ *   COMMIT;
+ */
+
+import { Database } from "bun:sqlite";
+import { getDbPath } from "../storage-sqlite";
+
+const FTS_TABLE = "part_fts";
+const FTS_VERSION = 2; // bump if schema changes and a rebuild is required
+
+export type FtsKind = "text" | "tool_name" | "tool_state" | "patch_file";
+
+// ---------------------------------------------------------------------------
+// One-shot ensure: open a writable connection, build/upgrade the index, close.
+// ---------------------------------------------------------------------------
+
+export interface EnsureResult {
+  built: boolean;
+  built_ms?: number;
+  error?: string;
+}
+
+// Module-level latch: intentionally not reset for the lifetime of the process.
+// We set this to `true` on BOTH success and failure to avoid a hot-loop where
+// every subsequent search re-opens a writable connection. A failure is
+// reported once via the EnsureResult and then we trust the next process
+// startup to retry. This matches "ensure once" semantics.
+let ensured = false;
+
+export function ensureFtsOnce(): EnsureResult {
+  if (ensured) return { built: false };
+  ensured = true; // latch first so any throw below doesn't cause retry storm
+  let db: Database | undefined;
+  try {
+    db = new Database(getDbPath()); // writable
+    // Wait politely for any concurrent OpenCode writer instead of failing
+    // immediately with SQLITE_BUSY. bun:sqlite default is 0ms.
+    db.exec("PRAGMA busy_timeout = 5000");
+    return ensureFts(db);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { built: false, error: message };
+  } finally {
+    db?.close();
+  }
+}
+
+/**
+ * Inspect existing state and rebuild only if necessary. The rebuild path is
+ * fully transactional: a crash mid-build rolls back and leaves the old index
+ * (or no index) intact.
+ */
+export function ensureFts(db: Database): EnsureResult {
+  const tableExists = db
+    .query(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+    .get(FTS_TABLE);
+
+  if (tableExists && triggersExist(db) && versionMatches(db)) {
+    // Conservative drift check. We'd rather skip a rebuild than do one
+    // needlessly: false-negative = slightly stale results until the next
+    // version bump; false-positive = unnecessary 3-second rebuild.
+    const expected = (db
+      .query(
+        `SELECT COUNT(*) c FROM part
+         WHERE json_valid(data)
+           AND json_extract(data, '$.type') IN ('text','tool','patch')`,
+      )
+      .get() as { c: number }).c;
+    const actual = (db
+      .query(`SELECT COUNT(DISTINCT part_id) c FROM ${FTS_TABLE}`)
+      .get() as { c: number }).c;
+    if (actual >= expected * 0.95) {
+      return { built: false };
+    }
+  }
+
+  const t0 = performance.now();
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    buildFts(db);
+    installTriggers(db);
+    recordVersion(db);
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+  return { built: true, built_ms: performance.now() - t0 };
+}
+
+// ---------------------------------------------------------------------------
+// Backfill
+// ---------------------------------------------------------------------------
+
+function buildFts(db: Database): void {
+  db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`);
+  db.exec(`
+    CREATE VIRTUAL TABLE ${FTS_TABLE} USING fts5(
+      content,
+      kind UNINDEXED,
+      part_id UNINDEXED,
+      message_id UNINDEXED,
+      session_id UNINDEXED,
+      tokenize = 'unicode61 remove_diacritics 2'
+    );
+  `);
+
+  // Text parts
+  db.exec(`
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT json_extract(data, '$.text'), 'text', id, message_id, session_id
+    FROM part
+    WHERE json_valid(data)
+      AND json_extract(data, '$.type') = 'text'
+      AND json_extract(data, '$.text') IS NOT NULL
+      AND json_extract(data, '$.text') != ''
+  `);
+
+  // Tool name + state title (skip blanks)
+  db.exec(`
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')),
+      'tool_name', id, message_id, session_id
+    FROM part
+    WHERE json_valid(data)
+      AND json_extract(data, '$.type') = 'tool'
+      AND json_extract(data, '$.tool') IS NOT NULL
+      AND trim(coalesce(json_extract(data, '$.tool'), '') || ' ' || coalesce(json_extract(data, '$.state.title'), '')) != ''
+  `);
+
+  // Tool state input + output as one blob
+  db.exec(`
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(data, '$.state.input'), '') || ' ' || coalesce(json_extract(data, '$.state.output'), '')),
+      'tool_state', id, message_id, session_id
+    FROM part
+    WHERE json_valid(data)
+      AND json_extract(data, '$.type') = 'tool'
+      AND json_extract(data, '$.state') IS NOT NULL
+      AND trim(coalesce(json_extract(data, '$.state.input'), '') || ' ' || coalesce(json_extract(data, '$.state.output'), '')) != ''
+  `);
+
+  // Patch files, flattened: one FTS row per file path (NOT the JSON array text)
+  db.exec(`
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT j.value, 'patch_file', p.id, p.message_id, p.session_id
+    FROM part p, json_each(json_extract(p.data, '$.files')) j
+    WHERE json_valid(p.data)
+      AND json_extract(p.data, '$.type') = 'patch'
+      AND json_extract(p.data, '$.files') IS NOT NULL
+      AND j.value IS NOT NULL
+      AND j.value != ''
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// Triggers
+//
+// Helpers below build the per-kind INSERTs as strings parameterized on the
+// row alias (NEW for INSERT, NEW for the re-insert side of UPDATE). The
+// CRITICAL property of every body is: json_valid(<alias>.data) gate FIRST.
+// Without this, a single malformed `part.data` write anywhere in OpenCode
+// would propagate `malformed JSON` up through the trigger and abort the
+// host INSERT, breaking OpenCode itself.
+// ---------------------------------------------------------------------------
+
+function insertFromPartSql(alias: "NEW"): string {
+  return `
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT json_extract(${alias}.data, '$.text'), 'text', ${alias}.id, ${alias}.message_id, ${alias}.session_id
+      WHERE json_valid(${alias}.data)
+        AND json_extract(${alias}.data, '$.type') = 'text'
+        AND json_extract(${alias}.data, '$.text') IS NOT NULL
+        AND json_extract(${alias}.data, '$.text') != '';
+
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(${alias}.data, '$.tool'), '') || ' ' || coalesce(json_extract(${alias}.data, '$.state.title'), '')),
+      'tool_name', ${alias}.id, ${alias}.message_id, ${alias}.session_id
+      WHERE json_valid(${alias}.data)
+        AND json_extract(${alias}.data, '$.type') = 'tool'
+        AND json_extract(${alias}.data, '$.tool') IS NOT NULL
+        AND trim(coalesce(json_extract(${alias}.data, '$.tool'), '') || ' ' || coalesce(json_extract(${alias}.data, '$.state.title'), '')) != '';
+
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT
+      trim(coalesce(json_extract(${alias}.data, '$.state.input'), '') || ' ' || coalesce(json_extract(${alias}.data, '$.state.output'), '')),
+      'tool_state', ${alias}.id, ${alias}.message_id, ${alias}.session_id
+      WHERE json_valid(${alias}.data)
+        AND json_extract(${alias}.data, '$.type') = 'tool'
+        AND json_extract(${alias}.data, '$.state') IS NOT NULL
+        AND trim(coalesce(json_extract(${alias}.data, '$.state.input'), '') || ' ' || coalesce(json_extract(${alias}.data, '$.state.output'), '')) != '';
+
+    INSERT INTO ${FTS_TABLE}(content, kind, part_id, message_id, session_id)
+    SELECT j.value, 'patch_file', ${alias}.id, ${alias}.message_id, ${alias}.session_id
+      FROM json_each(json_extract(${alias}.data, '$.files')) j
+      WHERE json_valid(${alias}.data)
+        AND json_extract(${alias}.data, '$.type') = 'patch'
+        AND json_extract(${alias}.data, '$.files') IS NOT NULL
+        AND j.value IS NOT NULL
+        AND j.value != '';
+  `;
+}
+
+function triggersExist(db: Database): boolean {
+  const triggers = db
+    .query(
+      `SELECT name FROM sqlite_master
+       WHERE type='trigger' AND name IN ('part_fts_ai', 'part_fts_ad', 'part_fts_au')`,
+    )
+    .all() as Array<{ name: string }>;
+  return triggers.length === 3;
+}
+
+function installTriggers(db: Database): void {
+  db.exec(`DROP TRIGGER IF EXISTS part_fts_ai`);
+  db.exec(`DROP TRIGGER IF EXISTS part_fts_ad`);
+  db.exec(`DROP TRIGGER IF EXISTS part_fts_au`);
+
+  db.exec(`
+    CREATE TRIGGER part_fts_ai AFTER INSERT ON part
+    BEGIN
+      ${insertFromPartSql("NEW")}
+    END;
+  `);
+
+  // DELETE only reads OLD.id, so no json_valid guard needed.
+  db.exec(`
+    CREATE TRIGGER part_fts_ad AFTER DELETE ON part
+    BEGIN
+      DELETE FROM ${FTS_TABLE} WHERE part_id = OLD.id;
+    END;
+  `);
+
+  // UPDATE: delete-then-insert ensures correctness across type changes.
+  // The DELETE uses OLD.id only (safe). The re-insert uses NEW.data, gated
+  // by json_valid (safe).
+  db.exec(`
+    CREATE TRIGGER part_fts_au AFTER UPDATE ON part
+    BEGIN
+      DELETE FROM ${FTS_TABLE} WHERE part_id = OLD.id;
+      ${insertFromPartSql("NEW")}
+    END;
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// Version metadata
+// ---------------------------------------------------------------------------
+
+function versionMatches(db: Database): boolean {
+  // This is called only from `ensureFts`, which is only invoked through
+  // `ensureFtsOnce` on a WRITABLE connection. If anyone ever calls this on a
+  // read-only handle, we want to know about it, so no try/catch here.
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS part_fts_meta (key TEXT PRIMARY KEY, value TEXT)`,
+  );
+  const row = db
+    .query(`SELECT value FROM part_fts_meta WHERE key = 'version'`)
+    .get() as { value: string } | undefined;
+  return row?.value === String(FTS_VERSION);
+}
+
+function recordVersion(db: Database): void {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS part_fts_meta (key TEXT PRIMARY KEY, value TEXT)`,
+  );
+  db.query(
+    `INSERT OR REPLACE INTO part_fts_meta(key, value) VALUES('version', ?)`,
+  ).run(String(FTS_VERSION));
+}
+
+// ---------------------------------------------------------------------------
+// Query API
+// ---------------------------------------------------------------------------
+
+export interface FtsHit {
+  part_id: string;
+  message_id: string;
+  session_id: string;
+  content: string; // the FTS-indexed snippet (text body, file path, tool name, etc.)
+  kind: FtsKind;
+  time_created: number;
+  session_title: string;
+  session_directory: string;
+}
+
+export interface FtsQueryOptions {
+  projectID: string | null;
+  role?: "user" | "assistant";
+  startTime?: number; // ms epoch, inclusive
+  endTime?: number; // ms epoch, inclusive
+  limit: number;
+}
+
+type Bind = string | number | bigint | null;
+
+/**
+ * Run an FTS5 MATCH query against indexed part content, joined back to
+ * message and session so we have everything needed to format a SearchMatch.
+ *
+ * Callers MUST wrap user input with `escapeFtsPhrase` so FTS5 treats it as
+ * a literal phrase rather than an operator expression (AND, OR, NEAR, parens).
+ *
+ * Any FTS5 syntax error or other SqliteError is caught and translated to an
+ * empty result set so a weird query never crashes the host plugin.
+ */
+export function searchFts(
+  db: Database,
+  query: string,
+  opts: FtsQueryOptions,
+): FtsHit[] {
+  const where: string[] = [`${FTS_TABLE}.content MATCH ?`];
+  const binds: Bind[] = [query];
+
+  if (opts.projectID) {
+    where.push("s.project_id = ?");
+    binds.push(opts.projectID);
+  }
+  if (opts.role) {
+    where.push("json_extract(m.data, '$.role') = ?");
+    binds.push(opts.role);
+  }
+  if (opts.startTime !== undefined) {
+    where.push("m.time_created >= ?");
+    binds.push(opts.startTime);
+  }
+  if (opts.endTime !== undefined) {
+    where.push("m.time_created <= ?");
+    binds.push(opts.endTime);
+  }
+  binds.push(opts.limit);
+
+  // No JOIN to `part`: the FTS row already contains the searchable content
+  // (text body, file path, tool name, etc.). Pulling 16KB+ data blobs over
+  // the FFI just to re-decode them in JS was the slow path.
+  const sql = `
+    SELECT
+      ${FTS_TABLE}.part_id    AS part_id,
+      ${FTS_TABLE}.message_id AS message_id,
+      ${FTS_TABLE}.session_id AS session_id,
+      ${FTS_TABLE}.content    AS content,
+      ${FTS_TABLE}.kind       AS kind,
+      m.time_created          AS time_created,
+      s.title                 AS session_title,
+      s.directory             AS session_directory
+    FROM ${FTS_TABLE}
+    JOIN message m ON m.id = ${FTS_TABLE}.message_id
+    JOIN session s ON s.id = ${FTS_TABLE}.session_id
+    WHERE ${where.join(" AND ")}
+    ORDER BY m.time_created DESC
+    LIMIT ?
+  `;
+
+  try {
+    return db.query(sql).all(...binds) as FtsHit[];
+  } catch (err: unknown) {
+    // FTS5 syntax errors should never crash the host. Log once and return
+    // an empty result so the caller can fall back gracefully if it wants.
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[history-search] FTS query failed: ${message}`);
+    return [];
+  }
+}
+
+/**
+ * Wrap a user-provided string so FTS5 treats it as a literal phrase, not an
+ * operator expression. Returns null if the input has no tokenizable content
+ * (empty, whitespace-only, all-punctuation) so callers can short-circuit.
+ *
+ * FTS5 phrase syntax: double-quoted, with embedded double-quotes escaped
+ * by doubling. Control characters are stripped (they truncate or syntax-error
+ * inside the FTS5 parser).
+ */
+export function escapeFtsPhrase(s: string): string | null {
+  // Strip ASCII control characters (incl. NUL, newlines, tabs). FTS5 treats
+  // whitespace as a token boundary anyway, so replacing with space is safe.
+  const cleaned = s.replace(/[\u0000-\u001f]/g, " ").trim();
+  if (cleaned === "") return null;
+  // Require at least one alphanumeric or unicode-letter character; FTS5
+  // tokenizes punctuation away and would receive zero tokens otherwise.
+  if (!/[\p{L}\p{N}]/u.test(cleaned)) return null;
+  return `"${cleaned.replace(/"/g, '""')}"`;
+}
+
+// ---------------------------------------------------------------------------
+// Title search (FTS doesn't help — titles are short, sessions are indexed)
+// ---------------------------------------------------------------------------
+
+export interface TitleHit {
+  id: string;
+  title: string;
+  directory: string;
+  time_updated: number;
+}
+
+export function searchTitles(
+  db: Database,
+  query: string,
+  opts: { projectID: string | null; limit: number },
+): TitleHit[] {
+  const like = `%${query.replace(/[\\%_]/g, (c) => "\\" + c)}%`;
+  const sql = `
+    SELECT id, title, directory, time_updated
+    FROM session
+    WHERE title LIKE ? ESCAPE '\\'
+      ${opts.projectID ? "AND project_id = ?" : ""}
+    ORDER BY time_updated DESC
+    LIMIT ?
+  `;
+  const binds: Bind[] = [like];
+  if (opts.projectID) binds.push(opts.projectID);
+  binds.push(opts.limit);
+  return db.query(sql).all(...binds) as TitleHit[];
+}

--- a/src/search/fuzzy.test.ts
+++ b/src/search/fuzzy.test.ts
@@ -15,6 +15,9 @@ describe("fuzzy search (unit tests with mocks)", () => {
       listParts: mockListParts,
       getStorageDir: async () => "/mock/storage",
       getCurrentProjectID: async () => MOCK_PROJECT_ID,
+      // Force fallthrough to the generator path so the mock generators above
+      // are exercised (instead of the real SQLite DB).
+      withSqlite: async () => null,
     }));
   });
 

--- a/src/search/fuzzy.ts
+++ b/src/search/fuzzy.ts
@@ -1,7 +1,8 @@
 import Fuse from "fuse.js";
 import type { Session, Message, Part } from "../storage-provider";
-import { listSessions, listMessages, listParts } from "../storage-provider";
+import { listSessions, listMessages, listParts, withSqlite } from "../storage-provider";
 import type { SearchMatch } from "./keyword";
+import { listSessionRowsSync, listMessageRowsSync, listPartRowsSync } from "../storage-sqlite";
 
 interface SearchableItem {
   session: Session;
@@ -12,24 +13,63 @@ interface SearchableItem {
   timestamp: number;
 }
 
+export interface FuzzyOptions {
+  threshold?: number;
+  limit?: number;
+  role?: "user" | "assistant";
+}
+
 export async function searchFuzzy(
   projectID: string | null,
   query: string,
-  options: {
-    threshold?: number; // 0.0 = exact, 1.0 = anything (default: 0.4)
-    limit?: number;
-    role?: "user" | "assistant";
-  } = {},
+  options: FuzzyOptions = {},
 ): Promise<SearchMatch[]> {
-  const threshold = options.threshold ?? 0.4;
-  const limit = options.limit ?? 50;
+  // Fast path: single SQLite connection for the corpus build.
+  const fast = await withSqlite((db) =>
+    searchFuzzySqlite(db, projectID, query, options),
+  );
+  if (fast !== null) return fast;
+  return searchFuzzyGenerators(projectID, query, options);
+}
 
-  // Build searchable index
+function searchFuzzySqlite(
+  db: any,
+  projectID: string | null,
+  query: string,
+  options: FuzzyOptions,
+): SearchMatch[] {
+  const items: SearchableItem[] = [];
+
+  const sessions = listSessionRowsSync(db, projectID);
+  for (const session of sessions) {
+    items.push({
+      session,
+      content: session.title,
+      type: "title",
+      timestamp: session.time.updated,
+    });
+
+    const messages = listMessageRowsSync(db, session.id, options.role);
+    for (const message of messages) {
+      const parts = listPartRowsSync(db, message.id);
+      for (const part of parts) {
+        addPartItems(items, session, message, part);
+      }
+    }
+  }
+
+  return runFuse(items, query, options);
+}
+
+async function searchFuzzyGenerators(
+  projectID: string | null,
+  query: string,
+  options: FuzzyOptions,
+): Promise<SearchMatch[]> {
   const items: SearchableItem[] = [];
 
   try {
     for await (const session of listSessions(projectID)) {
-      // Index session title
       items.push({
         session,
         content: session.title,
@@ -37,91 +77,102 @@ export async function searchFuzzy(
         timestamp: session.time.updated,
       });
 
-      // Index messages
       try {
         for await (const message of listMessages(session.id, options.role)) {
           try {
             for await (const part of listParts(message.id)) {
-              if (part.type === "text" && part.text) {
-                items.push({
-                  session,
-                  content: part.text,
-                  type: "message",
-                  messageID: message.id,
-                  partID: part.id,
-                  timestamp: message.time.created,
-                });
-              }
-
-              if (part.type === "tool" && part.tool) {
-                items.push({
-                  session,
-                  content: part.tool + " " + (part.state?.title || ""),
-                  type: "tool",
-                  messageID: message.id,
-                  partID: part.id,
-                  timestamp: message.time.created,
-                });
-              }
-
-              // Index file paths from tool inputs/outputs
-              if (part.type === "tool" && part.state) {
-                const inputStr = JSON.stringify(part.state.input || {});
-                const outputStr = part.state.output || "";
-                const combined = inputStr + " " + outputStr;
-
-                // Extract file path patterns
-                const pathMatches = combined.match(/(?:\/[^/\s]+)+/g);
-                if (pathMatches) {
-                  for (const path of pathMatches) {
-                    items.push({
-                      session,
-                      content: path,
-                      type: "filepath",
-                      messageID: message.id,
-                      partID: part.id,
-                      timestamp: message.time.created,
-                    });
-                  }
-                }
-              }
-
-              // Index file paths from patch parts
-              if (part.type === "patch" && part.files) {
-                for (const filePath of part.files) {
-                  items.push({
-                    session,
-                    content: filePath,
-                    type: "filepath",
-                    messageID: message.id,
-                    partID: part.id,
-                    timestamp: message.time.created,
-                  });
-                }
-              }
+              addPartItems(items, session, message, part);
             }
           } catch {
-            // Skip corrupt part files
             continue;
           }
         }
       } catch {
-        // Skip sessions with missing message directory
         continue;
       }
     }
   } catch {
-    // Handle missing sessions directory
     return [];
   }
 
-  // Perform fuzzy search
+  return runFuse(items, query, options);
+}
+
+function addPartItems(
+  items: SearchableItem[],
+  session: Session,
+  message: Message,
+  part: Part,
+): void {
+  if (part.type === "text" && part.text) {
+    items.push({
+      session,
+      content: part.text,
+      type: "message",
+      messageID: message.id,
+      partID: part.id,
+      timestamp: message.time.created,
+    });
+  }
+
+  if (part.type === "tool" && part.tool) {
+    items.push({
+      session,
+      content: part.tool + " " + (part.state?.title || ""),
+      type: "tool",
+      messageID: message.id,
+      partID: part.id,
+      timestamp: message.time.created,
+    });
+  }
+
+  if (part.type === "tool" && part.state) {
+    const inputStr = JSON.stringify(part.state.input || {});
+    const outputStr = part.state.output || "";
+    const combined = inputStr + " " + outputStr;
+    const pathMatches = combined.match(/(?:\/[^/\s]+)+/g);
+    if (pathMatches) {
+      for (const p of pathMatches) {
+        items.push({
+          session,
+          content: p,
+          type: "filepath",
+          messageID: message.id,
+          partID: part.id,
+          timestamp: message.time.created,
+        });
+      }
+    }
+  }
+
+  if (part.type === "patch" && part.files) {
+    for (const filePath of part.files) {
+      items.push({
+        session,
+        content: filePath,
+        type: "filepath",
+        messageID: message.id,
+        partID: part.id,
+        timestamp: message.time.created,
+      });
+    }
+  }
+}
+
+function runFuse(
+  items: SearchableItem[],
+  query: string,
+  options: FuzzyOptions,
+): SearchMatch[] {
+  const threshold = options.threshold ?? 0.4;
+  const limit = options.limit ?? 50;
+
   const fuse = new Fuse(items, {
     keys: ["content"],
     threshold,
     includeScore: true,
     includeMatches: true,
-    ignoreLocation: true, // Don't bias toward beginning of string
+    ignoreLocation: true,
     minMatchCharLength: 2,
   });
 
@@ -132,12 +183,10 @@ export async function searchFuzzy(
       const matchedText = result.matches?.[0]?.value || result.item.content;
       const matchIndex = result.matches?.[0]?.indices?.[0]?.[0] || 0;
 
-      // Extract context around the match
       const contextStart = Math.max(0, matchIndex - 100);
       const contextEnd = Math.min(matchedText.length, matchIndex + 200);
       const context = matchedText.slice(contextStart, contextEnd);
 
-      // Extract excerpt (the matched portion)
       const excerptStart = Math.max(0, matchIndex - 20);
       const excerptEnd = Math.min(matchedText.length, matchIndex + 80);
       const excerpt = matchedText.slice(excerptStart, excerptEnd);

--- a/src/search/fuzzy.ts
+++ b/src/search/fuzzy.ts
@@ -1,4 +1,5 @@
 import Fuse from "fuse.js";
+import type { Database } from "bun:sqlite";
 import type { Session, Message, Part } from "../storage-provider";
 import { listSessions, listMessages, listParts, withSqlite } from "../storage-provider";
 import type { SearchMatch } from "./keyword";
@@ -33,7 +34,7 @@ export async function searchFuzzy(
 }
 
 function searchFuzzySqlite(
-  db: any,
+  db: Database,
   projectID: string | null,
   query: string,
   options: FuzzyOptions,

--- a/src/search/fuzzy.ts
+++ b/src/search/fuzzy.ts
@@ -3,7 +3,7 @@ import type { Database } from "bun:sqlite";
 import type { Session, Message, Part } from "../storage-provider";
 import { listSessions, listMessages, listParts, withSqlite } from "../storage-provider";
 import type { SearchMatch } from "./keyword";
-import { listSessionRowsSync, listMessageRowsSync, listPartRowsSync } from "../storage-sqlite";
+import { searchFtsTrigram, searchTitles, escapeFtsPhrase, type FtsHit } from "./fts";
 
 interface SearchableItem {
   session: Session;
@@ -18,6 +18,8 @@ export interface FuzzyOptions {
   threshold?: number;
   limit?: number;
   role?: "user" | "assistant";
+  startTime?: number;
+  endTime?: number;
 }
 
 export async function searchFuzzy(
@@ -25,41 +27,99 @@ export async function searchFuzzy(
   query: string,
   options: FuzzyOptions = {},
 ): Promise<SearchMatch[]> {
-  // Fast path: single SQLite connection for the corpus build.
+  // SQLite fast path: trigram FTS index. Sub-second on hundreds of thousands
+  // of parts. Replaces the prior O(n) in-memory Fuse.js corpus rebuild.
   const fast = await withSqlite((db) =>
-    searchFuzzySqlite(db, projectID, query, options),
+    searchFuzzyTrigram(db, projectID, query, options),
   );
   if (fast !== null) return fast;
+  // JSON storage fallback (or tests that mock storage-provider).
   return searchFuzzyGenerators(projectID, query, options);
 }
 
-function searchFuzzySqlite(
+/**
+ * Trigram-tokenized FTS5 search. Handles typos and substrings natively
+ * because trigrams split words into overlapping 3-char chunks: "storage"
+ * indexes "sto", "tor", "ora", "rag", "age" — so "storag" (missing letter)
+ * matches via "sto", "tor", "ora". "Authentication" vs "autentication"
+ * (typo) shares "aut", "ute", "ten", "ent" trigrams and matches.
+ *
+ * The trigram index only covers text + tool_name. Title matches and
+ * everything else falls through to direct title LIKE.
+ */
+function searchFuzzyTrigram(
   db: Database,
   projectID: string | null,
   query: string,
   options: FuzzyOptions,
 ): SearchMatch[] {
-  const items: SearchableItem[] = [];
+  const limit = options.limit ?? 50;
+  const phrase = escapeFtsPhrase(query);
+  if (phrase === null) return [];
 
-  const sessions = listSessionRowsSync(db, projectID);
-  for (const session of sessions) {
-    items.push({
-      session,
-      content: session.title,
-      type: "title",
-      timestamp: session.time.updated,
+  const out: SearchMatch[] = [];
+
+  // 1) Titles via LIKE (substring matching is already fuzzy-ish on short text).
+  const titles = searchTitles(db, query, { projectID, limit });
+  for (const t of titles) {
+    if (out.length >= limit) break;
+    out.push({
+      sessionID: t.id,
+      sessionTitle: t.title,
+      timestamp: t.time_updated,
+      matchType: "title",
+      excerpt: t.title,
+      context: t.title,
+      projectDirectory: t.directory,
     });
-
-    const messages = listMessageRowsSync(db, session.id, options.role);
-    for (const message of messages) {
-      const parts = listPartRowsSync(db, message.id);
-      for (const part of parts) {
-        addPartItems(items, session, message, part);
-      }
-    }
   }
 
-  return runFuse(items, query, options);
+  // 2) Content via trigram MATCH.
+  const overfetch = Math.min(limit * 3, 500);
+  const hits = searchFtsTrigram(db, phrase, {
+    projectID,
+    role: options.role,
+    startTime: options.startTime,
+    endTime: options.endTime,
+    limit: overfetch,
+  });
+
+  const seen = new Set<string>();
+  for (const hit of hits) {
+    if (out.length >= limit) break;
+    const m = ftsHitToFuzzyMatch(hit, query);
+    const key = `${hit.part_id}|${m.matchType}|${m.excerpt}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(m);
+  }
+
+  return out.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+function ftsHitToFuzzyMatch(hit: FtsHit, query: string): SearchMatch {
+  // Trigram tokenization makes it hard to point at a single "best" match
+  // offset, so we just slice a window from the start of the content for the
+  // excerpt and a longer window for context. This matches the prior Fuse.js
+  // behavior closely enough that result display looks the same.
+  const content = hit.content;
+  const excerpt = content.slice(0, 100) || query;
+  const context = content.slice(0, 300) || excerpt;
+
+  const matchType: SearchMatch["matchType"] =
+    hit.kind === "text" ? "message" : "tool";
+
+  return {
+    sessionID: hit.session_id,
+    sessionTitle: hit.session_title,
+    timestamp: hit.time_created,
+    matchType,
+    excerpt,
+    context,
+    messageID: hit.message_id,
+    partID: hit.part_id,
+    projectDirectory: hit.session_directory,
+  };
 }
 
 async function searchFuzzyGenerators(

--- a/src/search/keyword.test.ts
+++ b/src/search/keyword.test.ts
@@ -15,6 +15,9 @@ describe("keyword search (unit tests with mocks)", () => {
       listParts: mockListParts,
       getStorageDir: async () => "/mock/storage",
       getCurrentProjectID: async () => MOCK_PROJECT_ID,
+      // Force fallthrough to the generator path so the mock generators above
+      // are exercised (instead of the real SQLite DB).
+      withSqlite: async () => null,
     }));
   });
 

--- a/src/search/keyword.ts
+++ b/src/search/keyword.ts
@@ -1,6 +1,8 @@
+import type { Database } from "bun:sqlite";
 import type { Session, Message, Part } from "../storage-provider";
 import { listSessions, listMessages, listParts, withSqlite } from "../storage-provider";
 import { listSessionRowsSync, listMessageRowsSync, listPartRowsSync } from "../storage-sqlite";
+import { searchFts, searchTitles, escapeFtsPhrase, type FtsHit, type FtsKind } from "./fts";
 
 export interface SearchMatch {
   sessionID: string;
@@ -19,6 +21,10 @@ export interface KeywordOptions {
   caseSensitive?: boolean;
   limit?: number;
   role?: "user" | "assistant";
+  /** ms epoch, inclusive. Pushed into SQL when on the SQLite fast paths. */
+  startTime?: number;
+  /** ms epoch, inclusive. Pushed into SQL when on the SQLite fast paths. */
+  endTime?: number;
 }
 
 export async function searchKeyword(
@@ -26,10 +32,14 @@ export async function searchKeyword(
   query: string,
   options: KeywordOptions = {},
 ): Promise<SearchMatch[]> {
-  // Fast path: SQLite available => single shared connection, sync iteration.
-  const fast = await withSqlite((db) =>
-    searchKeywordSqlite(db, projectID, query, options),
-  );
+  // FTS5 fast path: keyword (non-regex) + SQLite => indexed MATCH.
+  // Regex falls back to Phase 1 single-connection row scan.
+  const fast = await withSqlite((db) => {
+    if (options.regex) {
+      return searchKeywordSqlite(db, projectID, query, options);
+    }
+    return searchKeywordFts(db, projectID, query, options);
+  });
   if (fast !== null) return fast;
   // Legacy JSON path (or tests that mock storage-provider)
   return searchKeywordGenerators(projectID, query, options);
@@ -45,10 +55,132 @@ function buildPattern(query: string, options: KeywordOptions): RegExp {
 }
 
 // ---------------------------------------------------------------------------
-// SQLite fast path. One Database, plain for-loops, no async overhead per row.
+// FTS5 fast path. Uses the indexed part_fts table for content matches and a
+// LIKE query on `session.title` for title matches. Falls back to the Phase 1
+// row scan if the query has no tokenizable content (FTS5 would syntax-error).
+// ---------------------------------------------------------------------------
+function searchKeywordFts(
+  db: Database,
+  projectID: string | null,
+  query: string,
+  options: KeywordOptions,
+): SearchMatch[] {
+  const limit = options.limit || 50;
+  const phrase = escapeFtsPhrase(query);
+
+  // No tokenizable content (empty, whitespace, all punctuation). FTS5 would
+  // syntax-error. Fall back to the row scan which uses RegExp semantics.
+  if (phrase === null) {
+    return searchKeywordSqlite(db, projectID, query, options);
+  }
+
+  const out: SearchMatch[] = [];
+
+  // 1) Title matches via LIKE on session.title.
+  //    Skipped when a role filter is set — titles aren't role-specific.
+  if (!options.role) {
+    const titles = searchTitles(db, query, { projectID, limit });
+    for (const t of titles) {
+      if (out.length >= limit) break;
+      out.push({
+        sessionID: t.id,
+        sessionTitle: t.title,
+        timestamp: t.time_updated,
+        matchType: "title",
+        excerpt: t.title,
+        context: t.title,
+        projectDirectory: t.directory,
+      });
+    }
+  }
+
+  // 2) Content matches via FTS5.
+  // Over-fetch a bit because we'll dedupe by (partID, matchType).
+  const overfetch = Math.min(limit * 3, 500);
+  const hits = searchFts(db, phrase, {
+    projectID,
+    role: options.role,
+    startTime: options.startTime,
+    endTime: options.endTime,
+    limit: overfetch,
+  });
+
+  const pattern = buildPattern(query, options);
+  const seen = new Set<string>(); // partID|matchType to dedupe
+
+  for (const hit of hits) {
+    if (out.length >= limit) break;
+    const m = ftsHitToSearchMatch(hit, query, pattern);
+    if (!m) continue;
+    const key = `${hit.part_id}|${m.matchType}|${m.excerpt}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(m);
+  }
+
+  return out.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+/**
+ * Convert one FtsHit into a SearchMatch entry. We use the FTS-indexed `content`
+ * column directly instead of re-fetching and re-decoding the raw part.data
+ * blob. For text hits this is the message text; for patch_file hits it's the
+ * file path; for tool hits it's the tool name + title. This avoids dragging
+ * 16KB+ data blobs across the FFI per result.
+ *
+ * The pattern is the same RegExp the row-scan path uses, so the excerpt /
+ * context extraction logic is identical when both paths return the same hit.
+ */
+function ftsHitToSearchMatch(
+  hit: FtsHit,
+  query: string,
+  pattern: RegExp,
+): SearchMatch | null {
+  const base = {
+    sessionID: hit.session_id,
+    sessionTitle: hit.session_title,
+    timestamp: hit.time_created,
+    messageID: hit.message_id,
+    partID: hit.part_id,
+    projectDirectory: hit.session_directory,
+  };
+
+  const content = hit.content;
+  const m = content.match(pattern);
+  const idx = m ? content.indexOf(m[0]) : 0;
+  const contextStart = Math.max(0, idx - 100);
+  const contextEnd = Math.min(
+    content.length,
+    idx + (m?.[0].length ?? query.length) + 100,
+  );
+  const excerpt = m?.[0] ?? query;
+  const context = content.slice(contextStart, contextEnd);
+
+  switch (hit.kind as FtsKind) {
+    case "text":
+      return { ...base, matchType: "message", excerpt, context };
+    case "tool_name":
+      return { ...base, matchType: "tool", excerpt, context };
+    case "tool_state":
+      return { ...base, matchType: "filepath", excerpt, context };
+    case "patch_file":
+      // For patches, the entire content IS the file path. Surface it whole.
+      return {
+        ...base,
+        matchType: "filepath",
+        excerpt: content,
+        context: `Modified file: ${content}`,
+      };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// SQLite Phase-1 fast path (regex mode, or FTS fallback for empty queries).
+// One Database, plain for-loops, no async overhead per row.
 // ---------------------------------------------------------------------------
 function searchKeywordSqlite(
-  db: any,
+  db: Database,
   projectID: string | null,
   query: string,
   options: KeywordOptions,
@@ -77,6 +209,9 @@ function searchKeywordSqlite(
     const messages = listMessageRowsSync(db, session.id, options.role);
     for (const message of messages) {
       if (results.length >= limit) break;
+      // Apply date filter here too, since regex path doesn't have SQL pushdown.
+      if (options.startTime !== undefined && message.time.created < options.startTime) continue;
+      if (options.endTime !== undefined && message.time.created > options.endTime) continue;
       const parts = listPartRowsSync(db, message.id);
       for (const part of parts) {
         if (results.length >= limit) break;
@@ -129,7 +264,7 @@ async function searchKeywordGenerators(
 }
 
 // ---------------------------------------------------------------------------
-// Shared per-part matcher. Identical logic for both paths.
+// Shared per-part matcher. Identical logic for both row-scan paths.
 // ---------------------------------------------------------------------------
 function matchPart(
   results: SearchMatch[],

--- a/src/search/keyword.ts
+++ b/src/search/keyword.ts
@@ -1,5 +1,6 @@
 import type { Session, Message, Part } from "../storage-provider";
-import { listSessions, listMessages, listParts } from "../storage-provider";
+import { listSessions, listMessages, listParts, withSqlite } from "../storage-provider";
+import { listSessionRowsSync, listMessageRowsSync, listPartRowsSync } from "../storage-sqlite";
 
 export interface SearchMatch {
   sessionID: string;
@@ -13,24 +14,90 @@ export interface SearchMatch {
   projectDirectory: string;
 }
 
+export interface KeywordOptions {
+  regex?: boolean;
+  caseSensitive?: boolean;
+  limit?: number;
+  role?: "user" | "assistant";
+}
+
 export async function searchKeyword(
   projectID: string | null,
   query: string,
-  options: {
-    regex?: boolean;
-    caseSensitive?: boolean;
-    limit?: number;
-    role?: "user" | "assistant";
-  } = {},
+  options: KeywordOptions = {},
 ): Promise<SearchMatch[]> {
-  const results: SearchMatch[] = [];
-  const pattern = options.regex
+  // Fast path: SQLite available => single shared connection, sync iteration.
+  const fast = await withSqlite((db) =>
+    searchKeywordSqlite(db, projectID, query, options),
+  );
+  if (fast !== null) return fast;
+  // Legacy JSON path (or tests that mock storage-provider)
+  return searchKeywordGenerators(projectID, query, options);
+}
+
+function buildPattern(query: string, options: KeywordOptions): RegExp {
+  return options.regex
     ? new RegExp(query, options.caseSensitive ? "" : "i")
     : new RegExp(
         query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
         options.caseSensitive ? "" : "i",
       );
+}
 
+// ---------------------------------------------------------------------------
+// SQLite fast path. One Database, plain for-loops, no async overhead per row.
+// ---------------------------------------------------------------------------
+function searchKeywordSqlite(
+  db: any,
+  projectID: string | null,
+  query: string,
+  options: KeywordOptions,
+): SearchMatch[] {
+  const pattern = buildPattern(query, options);
+  const limit = options.limit || 50;
+  const results: SearchMatch[] = [];
+
+  const sessions = listSessionRowsSync(db, projectID);
+  for (const session of sessions) {
+    if (results.length >= limit) break;
+
+    if (pattern.test(session.title)) {
+      results.push({
+        sessionID: session.id,
+        sessionTitle: session.title,
+        timestamp: session.time.updated,
+        matchType: "title",
+        excerpt: session.title,
+        context: session.title,
+        projectDirectory: session.directory,
+      });
+      if (results.length >= limit) break;
+    }
+
+    const messages = listMessageRowsSync(db, session.id, options.role);
+    for (const message of messages) {
+      if (results.length >= limit) break;
+      const parts = listPartRowsSync(db, message.id);
+      for (const part of parts) {
+        if (results.length >= limit) break;
+        matchPart(results, pattern, query, session, message, part, limit);
+      }
+    }
+  }
+
+  return results.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy generator path (JSON storage). Unchanged behavior.
+// ---------------------------------------------------------------------------
+async function searchKeywordGenerators(
+  projectID: string | null,
+  query: string,
+  options: KeywordOptions,
+): Promise<SearchMatch[]> {
+  const results: SearchMatch[] = [];
+  const pattern = buildPattern(query, options);
   const limit = options.limit || 50;
 
   for await (const session of listSessions(projectID)) {
@@ -51,96 +118,107 @@ export async function searchKeyword(
 
     for await (const message of listMessages(session.id, options.role)) {
       if (results.length >= limit) break;
-
       for await (const part of listParts(message.id)) {
         if (results.length >= limit) break;
-
-        if (part.type === "text" && part.text && pattern.test(part.text)) {
-          const match = part.text.match(pattern);
-          const matchIndex = match ? part.text.indexOf(match[0]) : 0;
-          const contextStart = Math.max(0, matchIndex - 100);
-          const contextEnd = Math.min(
-            part.text.length,
-            matchIndex + match![0].length + 100,
-          );
-          const context = part.text.slice(contextStart, contextEnd);
-
-          results.push({
-            sessionID: session.id,
-            sessionTitle: session.title,
-            timestamp: message.time.created,
-            matchType: "message",
-            excerpt: match ? match[0] : query,
-            context: context,
-            messageID: message.id,
-            partID: part.id,
-            projectDirectory: session.directory,
-          });
-          if (results.length >= limit) break;
-        }
-
-        if (results.length >= limit) break;
-        if (part.type === "tool" && part.tool && pattern.test(part.tool)) {
-          results.push({
-            sessionID: session.id,
-            sessionTitle: session.title,
-            timestamp: message.time.created,
-            matchType: "tool",
-            excerpt: part.tool,
-            context: part.state?.title || part.tool,
-            messageID: message.id,
-            partID: part.id,
-            projectDirectory: session.directory,
-          });
-          if (results.length >= limit) break;
-        }
-
-        if (results.length >= limit) break;
-        if (part.type === "tool" && part.state) {
-          const inputStr = JSON.stringify(part.state.input || {});
-          const outputStr = part.state.output || "";
-
-          if (pattern.test(inputStr) || pattern.test(outputStr)) {
-            const matched = pattern.exec(inputStr) || pattern.exec(outputStr);
-            if (matched) {
-              results.push({
-                sessionID: session.id,
-                sessionTitle: session.title,
-                timestamp: message.time.created,
-                matchType: "filepath",
-                excerpt: matched[0],
-                context: part.state.title || part.tool || "",
-                messageID: message.id,
-                partID: part.id,
-                projectDirectory: session.directory,
-              });
-              if (results.length >= limit) break;
-            }
-          }
-        }
-
-        // Search patch parts for file paths
-        if (results.length < limit && part.type === "patch" && part.files) {
-          for (const filePath of part.files) {
-            if (results.length >= limit) break;
-            if (pattern.test(filePath)) {
-              results.push({
-                sessionID: session.id,
-                sessionTitle: session.title,
-                timestamp: message.time.created,
-                matchType: "filepath",
-                excerpt: filePath,
-                context: `Modified file: ${filePath}`,
-                messageID: message.id,
-                partID: part.id,
-                projectDirectory: session.directory,
-              });
-            }
-          }
-        }
+        matchPart(results, pattern, query, session, message, part, limit);
       }
     }
   }
 
   return results.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+// ---------------------------------------------------------------------------
+// Shared per-part matcher. Identical logic for both paths.
+// ---------------------------------------------------------------------------
+function matchPart(
+  results: SearchMatch[],
+  pattern: RegExp,
+  query: string,
+  session: Session,
+  message: Message,
+  part: Part,
+  limit: number,
+): void {
+  if (results.length >= limit) return;
+
+  if (part.type === "text" && part.text && pattern.test(part.text)) {
+    const match = part.text.match(pattern);
+    const matchIndex = match ? part.text.indexOf(match[0]) : 0;
+    const contextStart = Math.max(0, matchIndex - 100);
+    const contextEnd = Math.min(
+      part.text.length,
+      matchIndex + match![0].length + 100,
+    );
+    const context = part.text.slice(contextStart, contextEnd);
+
+    results.push({
+      sessionID: session.id,
+      sessionTitle: session.title,
+      timestamp: message.time.created,
+      matchType: "message",
+      excerpt: match ? match[0] : query,
+      context,
+      messageID: message.id,
+      partID: part.id,
+      projectDirectory: session.directory,
+    });
+    if (results.length >= limit) return;
+  }
+
+  if (part.type === "tool" && part.tool && pattern.test(part.tool)) {
+    results.push({
+      sessionID: session.id,
+      sessionTitle: session.title,
+      timestamp: message.time.created,
+      matchType: "tool",
+      excerpt: part.tool,
+      context: part.state?.title || part.tool,
+      messageID: message.id,
+      partID: part.id,
+      projectDirectory: session.directory,
+    });
+    if (results.length >= limit) return;
+  }
+
+  if (part.type === "tool" && part.state) {
+    const inputStr = JSON.stringify(part.state.input || {});
+    const outputStr = part.state.output || "";
+    if (pattern.test(inputStr) || pattern.test(outputStr)) {
+      const matched = pattern.exec(inputStr) || pattern.exec(outputStr);
+      if (matched) {
+        results.push({
+          sessionID: session.id,
+          sessionTitle: session.title,
+          timestamp: message.time.created,
+          matchType: "filepath",
+          excerpt: matched[0],
+          context: part.state.title || part.tool || "",
+          messageID: message.id,
+          partID: part.id,
+          projectDirectory: session.directory,
+        });
+        if (results.length >= limit) return;
+      }
+    }
+  }
+
+  if (part.type === "patch" && part.files) {
+    for (const filePath of part.files) {
+      if (results.length >= limit) return;
+      if (pattern.test(filePath)) {
+        results.push({
+          sessionID: session.id,
+          sessionTitle: session.title,
+          timestamp: message.time.created,
+          matchType: "filepath",
+          excerpt: filePath,
+          context: `Modified file: ${filePath}`,
+          messageID: message.id,
+          partID: part.id,
+          projectDirectory: session.directory,
+        });
+      }
+    }
+  }
 }

--- a/src/search/keyword.ts
+++ b/src/search/keyword.ts
@@ -2,7 +2,7 @@ import type { Database } from "bun:sqlite";
 import type { Session, Message, Part } from "../storage-provider";
 import { listSessions, listMessages, listParts, withSqlite } from "../storage-provider";
 import { listSessionRowsSync, listMessageRowsSync, listPartRowsSync } from "../storage-sqlite";
-import { searchFts, searchTitles, escapeFtsPhrase, type FtsHit, type FtsKind } from "./fts";
+import { searchFts, searchTitles, escapeFtsPhrase, type FtsHit } from "./fts";
 
 export interface SearchMatch {
   sessionID: string;
@@ -77,21 +77,21 @@ function searchKeywordFts(
   const out: SearchMatch[] = [];
 
   // 1) Title matches via LIKE on session.title.
-  //    Skipped when a role filter is set — titles aren't role-specific.
-  if (!options.role) {
-    const titles = searchTitles(db, query, { projectID, limit });
-    for (const t of titles) {
-      if (out.length >= limit) break;
-      out.push({
-        sessionID: t.id,
-        sessionTitle: t.title,
-        timestamp: t.time_updated,
-        matchType: "title",
-        excerpt: t.title,
-        context: t.title,
-        projectDirectory: t.directory,
-      });
-    }
+  //    Titles aren't role-specific (sessions don't have a single role), so
+  //    we include them regardless of the role filter. This matches the
+  //    row-scan path's behavior (matchPart-adjacent logic at line ~196).
+  const titles = searchTitles(db, query, { projectID, limit });
+  for (const t of titles) {
+    if (out.length >= limit) break;
+    out.push({
+      sessionID: t.id,
+      sessionTitle: t.title,
+      timestamp: t.time_updated,
+      matchType: "title",
+      excerpt: t.title,
+      context: t.title,
+      projectDirectory: t.directory,
+    });
   }
 
   // 2) Content matches via FTS5.
@@ -106,12 +106,14 @@ function searchKeywordFts(
   });
 
   const pattern = buildPattern(query, options);
-  const seen = new Set<string>(); // partID|matchType to dedupe
+  // Dedup key includes excerpt as a tie-breaker: tool_name and tool_state
+  // both map to matchType 'tool', so two FTS rows for the same part_id can
+  // collapse to the same (partID, matchType). The excerpt distinguishes them.
+  const seen = new Set<string>();
 
   for (const hit of hits) {
     if (out.length >= limit) break;
     const m = ftsHitToSearchMatch(hit, query, pattern);
-    if (!m) continue;
     const key = `${hit.part_id}|${m.matchType}|${m.excerpt}`;
     if (seen.has(key)) continue;
     seen.add(key);
@@ -125,8 +127,9 @@ function searchKeywordFts(
  * Convert one FtsHit into a SearchMatch entry. We use the FTS-indexed `content`
  * column directly instead of re-fetching and re-decoding the raw part.data
  * blob. For text hits this is the message text; for patch_file hits it's the
- * file path; for tool hits it's the tool name + title. This avoids dragging
- * 16KB+ data blobs across the FFI per result.
+ * file path; for tool hits it's the tool name (tool_name) or the input/output
+ * blob (tool_state). This avoids dragging 16KB+ data blobs across the FFI
+ * per result.
  *
  * The pattern is the same RegExp the row-scan path uses, so the excerpt /
  * context extraction logic is identical when both paths return the same hit.
@@ -135,7 +138,7 @@ function ftsHitToSearchMatch(
   hit: FtsHit,
   query: string,
   pattern: RegExp,
-): SearchMatch | null {
+): SearchMatch {
   const base = {
     sessionID: hit.session_id,
     sessionTitle: hit.session_title,
@@ -146,8 +149,8 @@ function ftsHitToSearchMatch(
   };
 
   const content = hit.content;
-  const m = content.match(pattern);
-  const idx = m ? content.indexOf(m[0]) : 0;
+  const m = pattern.exec(content);
+  const idx = m?.index ?? 0;
   const contextStart = Math.max(0, idx - 100);
   const contextEnd = Math.min(
     content.length,
@@ -156,13 +159,19 @@ function ftsHitToSearchMatch(
   const excerpt = m?.[0] ?? query;
   const context = content.slice(contextStart, contextEnd);
 
-  switch (hit.kind as FtsKind) {
+  // Exhaustive switch on FtsKind. If a new kind is added to fts.ts, the
+  // `never` witness at the end forces this to be updated at compile time.
+  switch (hit.kind) {
     case "text":
       return { ...base, matchType: "message", excerpt, context };
+    // Both tool_name and tool_state map to matchType "tool" — both represent
+    // a tool invocation, not a file path. Prior versions misreported
+    // tool_state as "filepath" because the row-scan path extracted file-path-
+    // shaped substrings out of the JSON blob; the FTS index doesn't have
+    // that semantic.
     case "tool_name":
-      return { ...base, matchType: "tool", excerpt, context };
     case "tool_state":
-      return { ...base, matchType: "filepath", excerpt, context };
+      return { ...base, matchType: "tool", excerpt, context };
     case "patch_file":
       // For patches, the entire content IS the file path. Surface it whole.
       return {
@@ -171,8 +180,11 @@ function ftsHitToSearchMatch(
         excerpt: content,
         context: `Modified file: ${content}`,
       };
+    default: {
+      const _exhaustive: never = hit.kind;
+      throw new Error(`unhandled FtsKind: ${String(_exhaustive)}`);
+    }
   }
-  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/storage-provider.ts
+++ b/src/storage-provider.ts
@@ -26,6 +26,9 @@ function useSqlite(): boolean {
 }
 
 // One-time logging latch for FTS errors so we don't spam the console.
+// Transient (busy/locked) failures are NOT latched here \u2014 they'll retry
+// automatically inside ensureFtsOnce after a backoff, and warning the user
+// about a brief lock contention would just be noise.
 let warnedFtsError = false;
 
 /**
@@ -51,7 +54,7 @@ export async function withSqlite<T>(
 ): Promise<T | null> {
   if (!useSqlite()) return null;
   const ftsResult = ensureFtsOnce();
-  if (ftsResult.error && !warnedFtsError) {
+  if (ftsResult.error && !ftsResult.transient && !warnedFtsError) {
     warnedFtsError = true;
     console.warn(
       `[history-search] FTS5 index unavailable: ${ftsResult.error}. ` +

--- a/src/storage-provider.ts
+++ b/src/storage-provider.ts
@@ -1,5 +1,6 @@
 import {
   dbExists,
+  withDb,
   listSessionsSqlite,
   listMessagesSqlite,
   listPartsSqlite,
@@ -12,8 +13,25 @@ import {
   getStorageDir,
 } from "./storage";
 import type { Session, Message, Part } from "./storage";
+import type { Database } from "bun:sqlite";
 
 const useSqlite = dbExists();
+
+/**
+ * If SQLite is available, opens a single shared connection, runs `fn`, then
+ * closes it. Returns the result. If SQLite is not available (legacy JSON
+ * backend, or storage-provider is mocked in tests), returns `null` so the
+ * caller can fall back to the generator-based path.
+ *
+ * This is the recommended entry point for any search code that wants the fast
+ * path: one connection per execute(), no per-row open/close.
+ */
+export async function withSqlite<T>(
+  fn: (db: Database) => Promise<T> | T,
+): Promise<T | null> {
+  if (!useSqlite) return null;
+  return await withDb(fn);
+}
 
 export async function* listSessions(
   projectID: string | null,

--- a/src/storage-provider.ts
+++ b/src/storage-provider.ts
@@ -14,14 +14,34 @@ import {
 } from "./storage";
 import type { Session, Message, Part } from "./storage";
 import type { Database } from "bun:sqlite";
-
-const useSqlite = dbExists();
+import { ensureFtsOnce } from "./search/fts";
 
 /**
- * If SQLite is available, opens a single shared connection, runs `fn`, then
- * closes it. Returns the result. If SQLite is not available (legacy JSON
- * backend, or storage-provider is mocked in tests), returns `null` so the
+ * Whether the SQLite backend is available. Evaluated fresh on each call so
+ * fresh OpenCode installs that create the DB *after* this plugin is loaded
+ * get the fast path on subsequent searches, not the JSON fallback forever.
+ */
+function useSqlite(): boolean {
+  return dbExists();
+}
+
+// One-time logging latch for FTS errors so we don't spam the console.
+let warnedFtsError = false;
+
+/**
+ * If SQLite is available, opens a single shared read-only connection, runs
+ * `fn`, then closes it. Returns the result. If SQLite is not available (legacy
+ * JSON backend, or storage-provider is mocked in tests), returns `null` so the
  * caller can fall back to the generator-based path.
+ *
+ * Before opening the read-only connection, this ensures the FTS5 index exists
+ * (which requires a brief writable connection). The first call may take a few
+ * seconds to build the index. Subsequent calls are microseconds.
+ *
+ * If the FTS build fails for any reason (DB busy, disk full, permission, etc.),
+ * we log a single warning and still proceed to the read-only path. The keyword
+ * search will fall back to the row-scan path (regex mode equivalent) if the
+ * FTS table is missing or unusable.
  *
  * This is the recommended entry point for any search code that wants the fast
  * path: one connection per execute(), no per-row open/close.
@@ -29,14 +49,28 @@ const useSqlite = dbExists();
 export async function withSqlite<T>(
   fn: (db: Database) => Promise<T> | T,
 ): Promise<T | null> {
-  if (!useSqlite) return null;
+  if (!useSqlite()) return null;
+  const ftsResult = ensureFtsOnce();
+  if (ftsResult.error && !warnedFtsError) {
+    warnedFtsError = true;
+    console.warn(
+      `[history-search] FTS5 index unavailable: ${ftsResult.error}. ` +
+        `Falling back to slower row-scan search. ` +
+        `See README "Rollback" section if you want to remove the index entirely.`,
+    );
+  } else if (ftsResult.built && ftsResult.built_ms !== undefined) {
+    console.warn(
+      `[history-search] Built FTS5 search index in ${Math.round(ftsResult.built_ms)}ms ` +
+        `(one-time setup, see README "Rollback" to remove).`,
+    );
+  }
   return await withDb(fn);
 }
 
 export async function* listSessions(
   projectID: string | null,
 ): AsyncGenerator<Session> {
-  if (useSqlite) {
+  if (useSqlite()) {
     yield* listSessionsSqlite(projectID);
   } else {
     yield* listSessionsJSON(projectID);
@@ -47,7 +81,7 @@ export async function* listMessages(
   sessionID: string,
   role?: "user" | "assistant",
 ): AsyncGenerator<Message> {
-  if (useSqlite) {
+  if (useSqlite()) {
     yield* listMessagesSqlite(sessionID, role);
   } else {
     yield* listMessagesJSON(sessionID, role);
@@ -55,7 +89,7 @@ export async function* listMessages(
 }
 
 export async function* listParts(messageID: string): AsyncGenerator<Part> {
-  if (useSqlite) {
+  if (useSqlite()) {
     yield* listPartsSqlite(messageID);
   } else {
     yield* listPartsJSON(messageID);

--- a/src/storage-sqlite.ts
+++ b/src/storage-sqlite.ts
@@ -17,9 +17,187 @@ export function dbExists(): boolean {
   }
 }
 
-function openDb(): Database {
+export function openDb(): Database {
   return new Database(getDbPath(), { readonly: true });
 }
+
+/**
+ * Run `fn` with a single shared read-only Database connection.
+ * Use this for any search path that touches multiple sessions/messages/parts
+ * so we don't pay the open/close cost per row.
+ */
+export async function withDb<T>(fn: (db: Database) => Promise<T> | T): Promise<T> {
+  const db = openDb();
+  try {
+    return await fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous, single-connection row iterators.
+//
+// These are the fast path. They take an existing `db` and return plain arrays
+// (or do callback iteration) rather than async generators, which avoids the
+// per-row event loop overhead AND lets us share one connection.
+// ---------------------------------------------------------------------------
+
+export interface RawPart {
+  id: string;
+  message_id: string;
+  session_id: string;
+  data: string;
+}
+
+export function listSessionRowsSync(
+  db: Database,
+  projectID: string | null,
+): Session[] {
+  const rows = (
+    projectID
+      ? db
+          .query(
+            `SELECT id, project_id, title, directory, time_created, time_updated
+             FROM session WHERE project_id = ?
+             ORDER BY time_updated DESC`,
+          )
+          .all(projectID)
+      : db
+          .query(
+            `SELECT id, project_id, title, directory, time_created, time_updated
+             FROM session
+             ORDER BY time_updated DESC`,
+          )
+          .all()
+  ) as Array<{
+    id: string;
+    project_id: string;
+    title: string;
+    directory: string;
+    time_created: number;
+    time_updated: number;
+  }>;
+
+  return rows.map((row) => ({
+    id: row.id,
+    projectID: row.project_id,
+    title: row.title,
+    directory: row.directory,
+    time: { created: row.time_created, updated: row.time_updated },
+  }));
+}
+
+export function listMessageRowsSync(
+  db: Database,
+  sessionID: string,
+  role?: "user" | "assistant",
+): Message[] {
+  const rows = db
+    .query(
+      `SELECT id, session_id, time_created, data
+       FROM message WHERE session_id = ?
+       ORDER BY time_created ASC`,
+    )
+    .all(sessionID) as Array<{
+    id: string;
+    session_id: string;
+    time_created: number;
+    data: string;
+  }>;
+
+  const out: Message[] = [];
+  for (const row of rows) {
+    const data = JSON.parse(row.data);
+    if (role && data.role !== role) continue;
+    out.push({
+      id: row.id,
+      sessionID: row.session_id,
+      role: data.role,
+      agent: data.agent || "",
+      time: { created: row.time_created },
+    });
+  }
+  return out;
+}
+
+export function listPartRowsSync(db: Database, messageID: string): Part[] {
+  const rows = db
+    .query(
+      `SELECT id, message_id, session_id, data
+       FROM part WHERE message_id = ?
+       ORDER BY time_created ASC`,
+    )
+    .all(messageID) as Array<{
+    id: string;
+    message_id: string;
+    session_id: string;
+    data: string;
+  }>;
+
+  const out: Part[] = [];
+  for (const row of rows) {
+    const part = decodePart(row);
+    if (part) out.push(part);
+  }
+  return out;
+}
+
+/**
+ * Decode a raw part row into our Part shape, or null if it's a type we
+ * don't search over (reasoning, step-start, etc).
+ */
+export function decodePart(row: {
+  id: string;
+  message_id: string;
+  session_id: string;
+  data: string;
+}): Part | null {
+  let data: any;
+  try {
+    data = JSON.parse(row.data);
+  } catch {
+    return null;
+  }
+
+  const type =
+    data.type === "text"
+      ? "text"
+      : data.type === "tool"
+        ? "tool"
+        : data.type === "file"
+          ? "file"
+          : data.type === "patch"
+            ? "patch"
+            : null;
+
+  if (!type) return null;
+
+  const part: Part = {
+    id: row.id,
+    messageID: row.message_id,
+    sessionID: row.session_id,
+    type: type as "text" | "tool" | "file" | "patch",
+  };
+
+  if (type === "text") {
+    part.text = data.text;
+  } else if (type === "tool") {
+    part.tool = data.tool;
+    part.state = data.state;
+  } else if (type === "patch") {
+    part.files = data.files;
+  }
+
+  return part;
+}
+
+// ---------------------------------------------------------------------------
+// Async generator wrappers (kept for back-compat with storage-provider.ts and
+// any callers that still iterate via for-await). Internally these now use the
+// sync helpers above, and accept an optional `db` so a parent scope can share
+// one connection across many calls.
+// ---------------------------------------------------------------------------
 
 export async function* listSessionsSqlite(
   projectID: string | null,
@@ -28,39 +206,8 @@ export async function* listSessionsSqlite(
   const shouldClose = db === undefined;
   const _db = db ?? openDb();
   try {
-    const rows = (
-      projectID
-        ? _db
-            .query(
-              `SELECT id, project_id, title, directory, time_created, time_updated
-               FROM session WHERE project_id = ?
-               ORDER BY time_updated DESC`,
-            )
-            .all(projectID)
-        : _db
-            .query(
-              `SELECT id, project_id, title, directory, time_created, time_updated
-               FROM session
-               ORDER BY time_updated DESC`,
-            )
-            .all()
-    ) as Array<{
-      id: string;
-      project_id: string;
-      title: string;
-      directory: string;
-      time_created: number;
-      time_updated: number;
-    }>;
-
-    for (const row of rows) {
-      yield {
-        id: row.id,
-        projectID: row.project_id,
-        title: row.title,
-        directory: row.directory,
-        time: { created: row.time_created, updated: row.time_updated },
-      };
+    for (const session of listSessionRowsSync(_db, projectID)) {
+      yield session;
     }
   } finally {
     if (shouldClose) _db.close();
@@ -70,92 +217,30 @@ export async function* listSessionsSqlite(
 export async function* listMessagesSqlite(
   sessionID: string,
   role?: "user" | "assistant",
+  db?: Database,
 ): AsyncGenerator<Message> {
-  const db = openDb();
+  const shouldClose = db === undefined;
+  const _db = db ?? openDb();
   try {
-    const rows = db
-      .query(
-        `SELECT id, session_id, time_created, data
-         FROM message WHERE session_id = ?
-         ORDER BY time_created ASC`,
-      )
-      .all(sessionID) as Array<{
-      id: string;
-      session_id: string;
-      time_created: number;
-      data: string;
-    }>;
-
-    for (const row of rows) {
-      const data = JSON.parse(row.data);
-      if (role && data.role !== role) continue;
-      yield {
-        id: row.id,
-        sessionID: row.session_id,
-        role: data.role,
-        agent: data.agent || "",
-        time: { created: row.time_created },
-      };
+    for (const message of listMessageRowsSync(_db, sessionID, role)) {
+      yield message;
     }
   } finally {
-    db.close();
+    if (shouldClose) _db.close();
   }
 }
 
 export async function* listPartsSqlite(
   messageID: string,
+  db?: Database,
 ): AsyncGenerator<Part> {
-  const db = openDb();
+  const shouldClose = db === undefined;
+  const _db = db ?? openDb();
   try {
-    const rows = db
-      .query(
-        `SELECT id, message_id, session_id, data
-         FROM part WHERE message_id = ?
-         ORDER BY time_created ASC`,
-      )
-      .all(messageID) as Array<{
-      id: string;
-      message_id: string;
-      session_id: string;
-      data: string;
-    }>;
-
-    for (const row of rows) {
-      const data = JSON.parse(row.data);
-
-      // Map SQLite part types to our interface types
-      const type =
-        data.type === "text"
-          ? "text"
-          : data.type === "tool"
-            ? "tool"
-            : data.type === "file"
-              ? "file"
-              : data.type === "patch"
-                ? "patch"
-                : null;
-
-      if (!type) continue; // Skip step-start, step-finish, reasoning, compaction, agent, etc.
-
-      const part: Part = {
-        id: row.id,
-        messageID: row.message_id,
-        sessionID: row.session_id,
-        type: type as "text" | "tool" | "file" | "patch",
-      };
-
-      if (type === "text") {
-        part.text = data.text;
-      } else if (type === "tool") {
-        part.tool = data.tool;
-        part.state = data.state;
-      } else if (type === "patch") {
-        part.files = data.files;
-      }
-
+    for (const part of listPartRowsSync(_db, messageID)) {
       yield part;
     }
   } finally {
-    db.close();
+    if (shouldClose) _db.close();
   }
 }

--- a/src/storage-sqlite.ts
+++ b/src/storage-sqlite.ts
@@ -10,11 +10,9 @@ export function getDbPath(): string {
 }
 
 export function dbExists(): boolean {
-  try {
-    return Bun.file(getDbPath()).size > 0;
-  } catch {
-    return false;
-  }
+  // Bun.file(path).size returns 0 when the file doesn't exist (never throws),
+  // so a simple comparison is sufficient. No try/catch needed.
+  return Bun.file(getDbPath()).size > 0;
 }
 
 export function openDb(): Database {
@@ -144,8 +142,21 @@ export function listPartRowsSync(db: Database, messageID: string): Part[] {
 }
 
 /**
+ * Discriminated union of the JSON shapes we care about in `part.data`.
+ */
+type SearchablePartJson =
+  | { type: "text"; text?: string }
+  | { type: "tool"; tool?: string; state?: Part["state"] }
+  | { type: "file" }
+  | { type: "patch"; files?: string[] };
+
+function isSearchableType(t: unknown): t is SearchablePartJson["type"] {
+  return t === "text" || t === "tool" || t === "file" || t === "patch";
+}
+
+/**
  * Decode a raw part row into our Part shape, or null if it's a type we
- * don't search over (reasoning, step-start, etc).
+ * don't search over (reasoning, step-start, etc), or the data is malformed.
  */
 export function decodePart(row: {
   id: string;
@@ -153,39 +164,31 @@ export function decodePart(row: {
   session_id: string;
   data: string;
 }): Part | null {
-  let data: any;
+  let parsed: unknown;
   try {
-    data = JSON.parse(row.data);
+    parsed = JSON.parse(row.data);
   } catch {
     return null;
   }
 
-  const type =
-    data.type === "text"
-      ? "text"
-      : data.type === "tool"
-        ? "tool"
-        : data.type === "file"
-          ? "file"
-          : data.type === "patch"
-            ? "patch"
-            : null;
-
-  if (!type) return null;
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const raw = parsed as { type?: unknown };
+  if (!isSearchableType(raw.type)) return null;
+  const data = raw as SearchablePartJson;
 
   const part: Part = {
     id: row.id,
     messageID: row.message_id,
     sessionID: row.session_id,
-    type: type as "text" | "tool" | "file" | "patch",
+    type: data.type,
   };
 
-  if (type === "text") {
+  if (data.type === "text") {
     part.text = data.text;
-  } else if (type === "tool") {
+  } else if (data.type === "tool") {
     part.tool = data.tool;
     part.state = data.state;
-  } else if (type === "patch") {
+  } else if (data.type === "patch") {
     part.files = data.files;
   }
 


### PR DESCRIPTION
Heads up: this PR adds tables and triggers to the user's `opencode.db`. Details below. Designed to be safe to merge, easy to roll back, and impossible to break OpenCode itself.

## What it does

Adds two FTS5 virtual tables (`part_fts`, `part_fts_tri`), one meta table (`part_fts_meta`), and three AFTER triggers on `part`. The plugin reads OpenCode's data through the new indexes instead of scanning every row.

## Why

Keyword search was O(n) over `part.data` with a regex check per row. Fuzzy was O(n) rebuilding a Fuse.js corpus per query. On my 3.9 GB / 209k-part DB, fuzzy took 15 seconds per query and keyword took up to 13 seconds for rare terms. Search felt broken.

FTS5's inverted index turns those queries into O(log n) MATCH lookups. Fuzzy goes from 15,500 ms to 30 ms.

## Benchmark on a 3.9 GB DB

| Query                        | Before (Phase 1) | After (FTS5) |
| ---------------------------- | ---------------: | -----------: |
| `storage` (common)           |              5ms |          57ms |
| `kubernetes` (rare)          |            287ms |          30ms |
| `webhook` (rare)             |          >13,000ms |          38ms |
| `the` (worst-case common)    |       (unbounded) |         360ms |
| `the` + `last 7 days` filter | broken (see below) |         273ms |
| `storag` fuzzy (typo)        |         15,527ms |          29ms |
| `authent` fuzzy (substring)  |         15,500ms |          38ms |

Worst case across any query is now ~400ms instead of 13+ seconds. Common-term keyword went from 5ms to 57ms (Phase 1 hit the 50-result limit almost instantly; FTS pays for the index but gives predictable tail latency).

Pre-existing correctness bug fixed: `date` filter was applied AFTER the 50-result limit, so `last 7 days` could return zero results when matches existed. Now pushed into SQL.

## What gets added to the user's DB

1. **`part_fts`** — FTS5 virtual table with unicode61 tokenizer (and 5 FTS5 shadow tables: `_data`, `_idx`, `_content`, `_docsize`, `_config`). One row per searchable piece of part content.
2. **`part_fts_tri`** — FTS5 virtual table with the trigram tokenizer (and its 5 shadow tables). Powers fuzzy. Indexes only `text` and `tool_name` kinds.
3. **`part_fts_meta`** — Two-row table tracking FTS schema version and the highest indexed `part.rowid`.
4. **Three AFTER triggers on `part`** (`part_fts_ai`, `part_fts_au`, `part_fts_ad`) that mirror inserts/updates/deletes into both FTS tables.

The plugin reads zero rows from OpenCode-owned tables outside those triggers.

## What it costs

- **Storage:** ~12-15% of total DB size (~550 MB on a 3.9 GB DB).
- **First-run build:** 2-3 seconds on small DBs, up to ~16 seconds on a 3.9 GB DB under load. One-time. Subsequent calls are microseconds (incremental top-up via rowid watermark).
- **First-run log line:** `[history-search] Built FTS5 search index in Nms (one-time setup, see README "Rollback" to remove).` — intentional, so users know the index was added.

## Why it can't break OpenCode

The trigger safety story is the most important part of this PR. Hardened against several failure modes:
1. **Malformed `part.data`** (non-JSON, binary, truncated stream): every `json_extract` is guarded by `json_valid(NEW.data)`. The trigger silently skips the row instead of crashing the parent INSERT.
2. **Non-array `$.files`** (e.g. patch with `files: "string"`): `json_each` is wrapped in `CASE WHEN json_type(...,'$.files')='array' THEN ... ELSE '[]' END`. Verified against real sqlite3 with 25 hostile JSON shapes; zero trigger crashes.
3. **OpenCode schema changes**: a drift detector samples the most recent text/tool/patch row and checks the JSON keys we depend on (`$.text`, `$.tool`, `$.files`). If a future OpenCode renames keys, the plugin logs a warning and forces a rebuild. Won't fix the drift (you'd need a plugin update) but surfaces it loudly.
4. **OpenCode drops or truncates `part`**: triggers vanish with the table; the next plugin invocation detects missing triggers via `triggersExist()` and does a full rebuild. If truncate resets rowid to 1, the watermark resets too (M3 fix).
5. **Concurrent writers**: `PRAGMA busy_timeout = 15000` so OpenCode writes wait politely during the brief index build. `BEGIN IMMEDIATE` wraps the rebuild for atomicity; `ROLLBACK` on any throw.
6. **Transient SQLite errors**: `SQLITE_BUSY` / `SQLITE_LOCKED` / `SQLITE_PROTOCOL` retry after 60 seconds. Permanent failures latch so we don't hot-loop.

All verified by tests in `src/search/fts.test.ts`.

## Rollback

Documented in the README. Safe to run while OpenCode is using the DB:
```sql
PRAGMA busy_timeout = 15000;
BEGIN IMMEDIATE;
  DROP TRIGGER IF EXISTS part_fts_ai;
  DROP TRIGGER IF EXISTS part_fts_au;
  DROP TRIGGER IF EXISTS part_fts_ad;
  DROP TABLE IF EXISTS part_fts;
  DROP TABLE IF EXISTS part_fts_tri;
  DROP TABLE IF EXISTS part_fts_meta;
COMMIT;
-- Optional: VACUUM to reclaim disk.
```

OpenCode never sees the plugin was there.

## Reading order for the diff

Five commits in chronological order, each builds on the last:
1. **`0fe9152`** — shared connection refactor (this is PR #7; the FTS work needs it)
2. **`191f708`** — initial FTS5 keyword index. First-cut. Subsequent commits harden it.
3. **`069639e`** — three rounds of internal review caught a real index-doubling bug (H1: incremental backfill double-indexed trigger-indexed rows). Also adds: schema drift detection, transient/permanent error classification, json_valid guards on every trigger, json_each CASE guard, busy_timeout bump, atomic rebuild.
4. **`0fc5eab`** — README sections for Performance, FTS5 Index, Rollback, Verification.
5. **`ce5549a`** — FTS5 trigram index replaces Fuse.js corpus rebuild for fuzzy mode. Adds the second virtual table + parallel trigger logic + dist rebuild.

If you'd rather see a single squashed diff for review, let me know and I can rebase.

## Tests

130 pass, 0 fail. 35 new FTS-specific tests in `src/search/fts.test.ts` cover:

- Malformed JSON tolerance (5 hostile shapes: non-JSON, `$.files` as string/object/number/missing)
- Backfill atomicity (ROLLBACK preserves prior state)
- H1 regression (double-index after trigger fire)
- Watermark reset on truncated `part` table (M3)
- Schema drift detection
- Trigger DELETE/UPDATE/INSERT parity across both FTS tables
- Trigram index scope (text + tool_name only, not tool_state or patch_file)
- Trigram project-filter regression (no cross-project leakage)
- escapeFtsPhrase edge cases (empty, all-punct, control chars, unicode)

Pre-existing integration tests (`fuzzy.integration.test.ts`, `keyword.integration.test.ts`) reference a hardcoded `MAIN_PROJECT_ID` from your local data; they fail in any other environment. Not modified by this PR.

## A note on the README

The "Fast" feature bullet used to claim "<50ms even with thousands of messages." That's true at your scale. Updated to "Sub-50ms on small histories, sub-100ms on most queries even at hundreds of thousands of parts" with a link to the Performance section so both ends are honest.