### PR TITLE
fix(file-trace): match relative-path queries against absolute stored paths

### DIFF
--- a/src/search/file-trace.test.ts
+++ b/src/search/file-trace.test.ts
@@ -89,6 +89,24 @@ describe("file-trace search", () => {
     db.run(`INSERT INTO session VALUES ('ses_g', 'proj_main', 'malformed-patch', '/mock/main', 'malformed patch', 'v1', 1775386800000, 1775386801200)`);
     db.run(`INSERT INTO message VALUES ('msg_g1', 'ses_g', 1775386800000, 1775386800000, '{"role":"assistant","agent":"build"}')`);
     db.run(`INSERT INTO part VALUES ('part_g1_patch', 'msg_g1', 'ses_g', 1775386800100, 1775386800100, '{"type":"patch","files":oops}')`);
+
+    // Absolute-path fixtures. Modern OpenCode (and many editors) record the
+    // edit/write filePath as an absolute path (e.g. the full
+    // /Users/.../project/src/foo.ts string). The README's examples encourage
+    // users to query with a project-relative path like "src/auth.ts", so we
+    // need to confirm those queries match against absolute stored paths.
+    db.run(`INSERT INTO session VALUES ('ses_abs', 'proj_main', 'absolute-path-session', '/mock/main', 'absolute path session', 'v1', 1775400000000, 1775400001200)`);
+    db.run(`INSERT INTO message VALUES ('msg_abs1', 'ses_abs', 1775400000000, 1775400000000, '{"role":"user","agent":"user"}')`);
+    db.run(`INSERT INTO message VALUES ('msg_abs2', 'ses_abs', 1775400001000, 1775400001000, '{"role":"assistant","agent":"build"}')`);
+    db.run(`INSERT INTO part VALUES ('part_abs1_text', 'msg_abs1', 'ses_abs', 1775400000000, 1775400000000, '{"type":"text","text":"edit the FTS module"}')`);
+    db.run(`INSERT INTO part VALUES ('part_abs2_tool', 'msg_abs2', 'ses_abs', 1775400001100, 1775400001100, '{"type":"tool","tool":"edit","state":{"status":"completed","input":{"filePath":"/Users/me/project/src/search/fts.ts"},"output":"Edited fts.ts","title":"Edit FTS module"}}')`);
+    db.run(`INSERT INTO part VALUES ('part_abs2_patch', 'msg_abs2', 'ses_abs', 1775400001200, 1775400001200, '{"type":"patch","files":["/Users/me/project/src/search/fts.ts"]}')`);
+
+    // Decoy: similar suffix but should NOT match a "src/search/fts.ts" query
+    // because the suffix check requires a leading slash before the query.
+    db.run(`INSERT INTO session VALUES ('ses_decoy', 'proj_main', 'decoy-suffix-session', '/mock/main', 'decoy suffix session', 'v1', 1775500000000, 1775500001200)`);
+    db.run(`INSERT INTO message VALUES ('msg_decoy1', 'ses_decoy', 1775500001000, 1775500001000, '{"role":"assistant","agent":"build"}')`);
+    db.run(`INSERT INTO part VALUES ('part_decoy_tool', 'msg_decoy1', 'ses_decoy', 1775500001100, 1775500001100, '{"type":"tool","tool":"edit","state":{"status":"completed","input":{"filePath":"/Users/me/other-src/search/fts.ts"},"output":"Edited","title":"Edit other fts"}}')`);
   });
 
   afterAll(() => {
@@ -286,6 +304,35 @@ describe("file-trace search", () => {
       const results = traceFileSqlite(db, null, "src/auth.ts");
       const sesE = results.find((r) => r.sessionID === "ses_e");
       expect(sesE?.userPrompt).toBe("touch auth in other project");
+    });
+  });
+
+  describe("Group 8: relative-query matching against absolute stored paths", () => {
+    test("matches a project-relative query against an absolute stored filePath", () => {
+      // Stored: /Users/me/project/src/search/fts.ts
+      // Query:  src/search/fts.ts
+      // Should match. Previously failed because isExactPath required strict equality.
+      const results = traceFileSqlite(db, "proj_main", "src/search/fts.ts");
+      expect(results.find((r) => r.sessionID === "ses_abs")).toBeDefined();
+    });
+
+    test("matches a basename query against an absolute stored filePath", () => {
+      const results = traceFileSqlite(db, "proj_main", "fts.ts");
+      expect(results.find((r) => r.sessionID === "ses_abs")).toBeDefined();
+    });
+
+    test("matches absolute query against absolute stored filePath", () => {
+      const results = traceFileSqlite(db, "proj_main", "/Users/me/project/src/search/fts.ts");
+      expect(results.find((r) => r.sessionID === "ses_abs")).toBeDefined();
+    });
+
+    test("does not match a similar-suffix path that is missing the leading slash", () => {
+      // Stored: /Users/me/other-src/search/fts.ts
+      // Query:  src/search/fts.ts
+      // Must NOT match. The slash-prefixed suffix check is what prevents this.
+      const results = traceFileSqlite(db, "proj_main", "src/search/fts.ts");
+      const decoy = results.find((r) => r.sessionID === "ses_decoy");
+      expect(decoy).toBeUndefined();
     });
   });
 });

--- a/src/search/file-trace.ts
+++ b/src/search/file-trace.ts
@@ -22,9 +22,10 @@ export function traceFileSqlite(
   options?: TraceFileOptions
 ): FileTraceResult[] {
   const normalizedQuery = queryPath.replace(/\\/g, "/");
-  const isExactPath = normalizedQuery.includes("/");
 
-  // Use broad SQL LIKE matching, then refine to exact/basename rules in TypeScript.
+  // Use broad SQL LIKE matching, then refine to suffix rules in TypeScript
+  // via isMatch (matches both basename queries like "auth.ts" and relative
+  // path queries like "src/auth.ts" against absolute filepaths).
   const likePattern = `%${normalizedQuery}%`;
 
   const projectFilter = projectID !== null ? "AND s.project_id = ?" : "";
@@ -99,7 +100,7 @@ export function traceFileSqlite(
     let matchedPath: string | null = null;
     
     if (row.source_priority === 0 && row.matched_file_path_tool) {
-      if (isMatch(row.matched_file_path_tool, normalizedQuery, isExactPath)) {
+      if (isMatch(row.matched_file_path_tool, normalizedQuery)) {
         matchedPath = row.matched_file_path_tool;
       }
     } else if (row.source_priority === 1 && row.matched_files_patch) {
@@ -107,7 +108,7 @@ export function traceFileSqlite(
         const parsed = JSON.parse(row.matched_files_patch);
         if (Array.isArray(parsed.files)) {
           for (const f of parsed.files) {
-            if (isMatch(f, normalizedQuery, isExactPath)) {
+            if (isMatch(f, normalizedQuery)) {
               matchedPath = f;
               break;
             }
@@ -185,10 +186,15 @@ export function traceFileSqlite(
   return results.slice(0, limit);
 }
 
-function isMatch(path: string, query: string, isExact: boolean): boolean {
-  if (isExact) {
-    return path === query;
-  }
+function isMatch(path: string, query: string): boolean {
+  // The stored filepath from edit/write tool calls is always absolute
+  // (e.g. "/Users/me/project/src/auth.ts"). The query is usually a
+  // basename ("auth.ts") or a project-relative path ("src/auth.ts"),
+  // per the README examples. Match when:
+  //   * the stored path equals the query exactly, OR
+  //   * the stored path ends with "/query"
+  // The slash prefix on the suffix check avoids false positives like a
+  // query of "auth.ts" matching "fake-auth.ts" or "src/oauth.ts".
   return path === query || path.endsWith(`/${query}`);
 }
 


### PR DESCRIPTION
The README's filePath examples (`src/install.ts`, `src/utils/`, `auth module`) suggest the agent should pass project-relative paths or basenames. That works for basenames but silently fails for relative paths that contain a slash.

## Reproducer

Modern OpenCode records the edit/write `filePath` as an absolute path:
```
Stored: /Users/me/project/src/auth.ts
Query:  src/auth.ts   ← as the README recommends
```

Run via the tool: zero results.

I hit this on a real query against my own DB. Confirmed via the README example "Find me sessions where you created or modified `src/install.ts`" — that exact form returns nothing.

## Why

In `src/search/file-trace.ts`, the old `isMatch`:

```ts
function isMatch(path: string, query: string, isExact: boolean): boolean {
  if (isExact) {
    return path === query;
  }
  return path === query || path.endsWith(`/${query}`);
}
```

`isExactPath` is `true` whenever the query contains a slash. So `src/auth.ts` becomes "exact mode," and strict equality against an absolute stored path fails every time.

## Fix

Collapse both branches into one suffix check:

```ts
function isMatch(path: string, query: string): boolean {
  return path === query || path.endsWith(`/${query}`);
}
```

The slash prefix on the suffix check prevents false positives like `src/auth.ts` matching `/Users/me/other-src/auth.ts`. There's a regression test for exactly that.

`isExact` was unused after the collapse, so it's gone from the signature. `isExactPath` in `traceFileSqlite()` also went away.

## Tests

4 new regression tests in a new Group 8 in `file-trace.test.ts`. Two new fixture sessions store absolute paths (`/Users/me/project/src/search/fts.ts` and a decoy `/Users/me/other-src/search/fts.ts`).

- ✅ Relative-path query matches absolute stored path
- ✅ Basename query matches absolute stored path
- ✅ Absolute query matches absolute stored path
- ✅ Similar-suffix decoy does NOT match (`src/search/fts.ts` ≠ `/Users/me/other-src/search/fts.ts`)

All 99 tests pass. The existing fixtures use relative stored paths, so existing behavior is unchanged.

## Note

I have two perf PRs (#7 and #8) up. This one is independent — branched off `main`, no dependency on the perf work.