### PR TITLE
feat: add list mode to browse sessions grouped by folder

### DIFF
--- a/dist/history-search.ts
+++ b/dist/history-search.ts
@@ -241,7 +241,8 @@ async function searchKeyword(projectID, query, options = {}) {
         timestamp: session.time.updated,
         matchType: "title",
         excerpt: session.title,
-        context: session.title
+        context: session.title,
+        projectDirectory: session.directory
       });
       if (results.length >= limit)
         break;
@@ -1966,6 +1967,54 @@ async function traceFile(projectID, filePath, options) {
 }
 
 // src/format.ts
+var LIST_TITLE_MAX = 60;
+function truncateTitle(title) {
+  const clean = (title || "(untitled)").trim() || "(untitled)";
+  if (clean.length <= LIST_TITLE_MAX)
+    return clean;
+  return clean.slice(0, LIST_TITLE_MAX - 1).trimEnd() + "\u2026";
+}
+function formatLocalTimestamp(millis) {
+  const d = new Date(millis);
+  const pad = (n) => String(n).padStart(2, "0");
+  const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  return `${date} ${time}`;
+}
+function formatListResults(sessions) {
+  if (sessions.length === 0) {
+    return "No sessions found.";
+  }
+  const groups = new Map;
+  for (const session of sessions) {
+    const dir = session.directory || "(unknown directory)";
+    const existing = groups.get(dir);
+    if (existing) {
+      existing.push(session);
+    } else {
+      groups.set(dir, [session]);
+    }
+  }
+  const folders = Array.from(groups.entries()).map(([directory, items]) => {
+    items.sort((a, b) => b.time.updated - a.time.updated);
+    const mostRecent = items[0]?.time.updated ?? 0;
+    return { directory, items, mostRecent };
+  });
+  folders.sort((a, b) => b.mostRecent - a.mostRecent);
+  const lines = [];
+  for (const folder of folders) {
+    const count = folder.items.length;
+    const plural = count === 1 ? "session" : "sessions";
+    lines.push(`== ${folder.directory}  (${count} ${plural}) ==`);
+    for (const session of folder.items) {
+      const ts = formatLocalTimestamp(session.time.updated);
+      const title = truncateTitle(session.title);
+      lines.push(`  ${ts}    ${title}  ${session.id}`);
+    }
+  }
+  return lines.join(`
+`);
+}
 function formatResults(matches) {
   if (matches.length === 0) {
     return "No matches found in conversation history.";
@@ -2021,9 +2070,10 @@ function formatTraceResults(matches) {
 
 // src/index.ts
 var historySearch = tool({
-  description: `Search through past conversation histories. Use searchAllProjects=true to search ALL projects on this machine. Searches session titles, message content, tool invocations, and file paths. Supports keyword search, regex patterns, fuzzy search (for typos and variations), and date filtering.`,
+  description: `Search through past conversation histories. Use searchAllProjects=true to search ALL projects on this machine. Searches session titles, message content, tool invocations, and file paths. Supports keyword search, regex patterns, fuzzy search (for typos and variations), and date filtering. Use list=true to browse all sessions grouped by folder with per-folder counts (ignores query/filePath).`,
   args: {
-    query: tool.schema.string().optional().describe("Search query (keyword, regex pattern, or fuzzy search term). Required unless filePath is provided."),
+    query: tool.schema.string().optional().describe("Search query (keyword, regex pattern, or fuzzy search term). Required unless filePath or list is provided."),
+    list: tool.schema.boolean().optional().describe("Set to true to list ALL sessions grouped by folder with per-folder counts, newest-first. Ignores query, filePath, mode, regex, fuzzy, and role. Respects searchAllProjects, date, and limit. Use when the user wants an overview of their sessions, e.g. 'list my sessions' or 'show all my conversations by folder'."),
     filePath: tool.schema.string().optional().describe("File path to trace touch history (e.g., 'src/auth.ts'). If provided, query, mode, regex, caseSensitive, fuzzyThreshold, and role are ignored."),
     searchAllProjects: tool.schema.boolean().optional().describe("Set to true to search ALL projects on your machine across all repositories, not just the current one. Default: false (current repo only). Use when user asks to search globally, across all projects, machine-wide, or everywhere."),
     mode: tool.schema.enum(["keyword", "fuzzy"]).optional().describe("Search mode: 'keyword' for exact matches, 'fuzzy' for typo-tolerant matching (default: keyword)"),
@@ -2035,10 +2085,25 @@ var historySearch = tool({
     role: tool.schema.enum(["user", "assistant"]).optional().describe("Filter by message role: 'user' for your messages only, 'assistant' for AI responses only. Ignored if filePath is provided.")
   },
   async execute(args) {
-    if (!args.query && !args.filePath) {
-      throw new Error("Either 'query' or 'filePath' must be provided.");
+    if (!args.list && !args.query && !args.filePath) {
+      throw new Error("Either 'query', 'filePath', or 'list' must be provided.");
     }
     const projectID = args.searchAllProjects ? null : await getCurrentProjectID();
+    if (args.list) {
+      const sessions = [];
+      for await (const session of listSessions2(projectID)) {
+        sessions.push(session);
+      }
+      let filtered = sessions;
+      if (args.date) {
+        const dateRange = parseDateFilter(args.date);
+        filtered = filterByDate(sessions.map((s) => ({ ...s, timestamp: s.time.updated })), dateRange);
+      }
+      filtered.sort((a, b) => b.time.updated - a.time.updated);
+      const limit = args.limit ?? 50;
+      const capped = filtered.slice(0, limit);
+      return formatListResults(capped);
+    }
     if (args.filePath) {
       let matches2 = await traceFile(projectID, args.filePath, {
         limit: args.limit

--- a/install.ts
+++ b/install.ts
@@ -7,7 +7,8 @@ import { homedir } from "os";
 const TOOL_DESCRIPTION = `Search through past conversation histories.
 
 Parameters:
-- query: Search term (keyword, regex, or fuzzy). Required unless filePath provided.
+- query: Search term (keyword, regex, or fuzzy). Required unless filePath or list provided.
+- list: boolean — set to true to list ALL sessions grouped by folder with per-folder counts, newest-first. Ignores query/filePath/mode/regex/fuzzy/role. Respects searchAllProjects, date, and limit. Default: false.
 - searchAllProjects: boolean — set to true to search ALL projects on this machine. Default: false (current repo only).
 - filePath: Trace which sessions modified a specific file path.
 - mode: "keyword" (default) or "fuzzy" search.
@@ -31,6 +32,8 @@ Examples:
 - "Search for 'storag' using fuzzy mode" (uses mode: "fuzzy")
 - "Find conversations about authentication globally" (uses searchAllProjects: true)
 - "Which sessions modified src/storage.ts?" (uses filePath)
+- "List all my sessions grouped by folder" (uses list: true, searchAllProjects: true)
+- "Show my sessions in this repo from the last 7 days" (uses list: true, date: "last 7 days")
 
 Works with OpenCode v1.2+ (SQLite) and v1.1.x (JSON files).`;
 

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,7 +1,8 @@
 import { test, expect, describe } from "bun:test";
-import { formatResults, formatTraceResults } from "./format";
+import { formatResults, formatTraceResults, formatListResults } from "./format";
 import type { SearchMatch } from "./search/keyword";
 import type { FileTraceResult } from "./search/file-trace";
+import type { Session } from "./storage";
 
 describe("formatResults", () => {
   test("renders a single match with project directory", () => {
@@ -125,5 +126,95 @@ describe("formatTraceResults", () => {
   test("returns empty message when no matches", () => {
     const output = formatTraceResults([]);
     expect(output).toBe("No file trace matches found in conversation history.");
+  });
+});
+
+describe("formatListResults", () => {
+  const mkSession = (
+    id: string,
+    directory: string,
+    title: string,
+    updated: number,
+  ): Session => ({
+    id,
+    projectID: "proj",
+    title,
+    directory,
+    time: { created: updated, updated },
+  });
+
+  test("returns empty message when no sessions", () => {
+    expect(formatListResults([])).toBe("No sessions found.");
+  });
+
+  test("groups sessions by directory with per-folder counts", () => {
+    const sessions: Session[] = [
+      mkSession("ses_a", "/projects/alpha", "Alpha one", 3000),
+      mkSession("ses_b", "/projects/alpha", "Alpha two", 2000),
+      mkSession("ses_c", "/projects/beta", "Beta one", 1000),
+    ];
+
+    const output = formatListResults(sessions);
+    expect(output).toContain("== /projects/alpha  (2 sessions) ==");
+    expect(output).toContain("== /projects/beta  (1 session) ==");
+    expect(output).toContain("ses_a");
+    expect(output).toContain("ses_b");
+    expect(output).toContain("ses_c");
+    expect(output).toContain("Alpha one");
+  });
+
+  test("sorts folders by most-recently-updated session (newest first)", () => {
+    const sessions: Session[] = [
+      mkSession("ses_old", "/projects/older", "Older", 1000),
+      mkSession("ses_new", "/projects/newer", "Newer", 9000),
+    ];
+
+    const output = formatListResults(sessions);
+    const newerIdx = output.indexOf("/projects/newer");
+    const olderIdx = output.indexOf("/projects/older");
+    expect(newerIdx).toBeGreaterThanOrEqual(0);
+    expect(olderIdx).toBeGreaterThan(newerIdx);
+  });
+
+  test("sorts sessions newest-first within a folder", () => {
+    const sessions: Session[] = [
+      mkSession("ses_mid", "/projects/x", "Mid", 2000),
+      mkSession("ses_new", "/projects/x", "New", 3000),
+      mkSession("ses_old", "/projects/x", "Old", 1000),
+    ];
+
+    const output = formatListResults(sessions);
+    const newIdx = output.indexOf("ses_new");
+    const midIdx = output.indexOf("ses_mid");
+    const oldIdx = output.indexOf("ses_old");
+    expect(newIdx).toBeLessThan(midIdx);
+    expect(midIdx).toBeLessThan(oldIdx);
+  });
+
+  test("truncates long titles to ~60 chars", () => {
+    const longTitle = "x".repeat(120);
+    const sessions: Session[] = [
+      mkSession("ses_long", "/projects/x", longTitle, 1000),
+    ];
+
+    const output = formatListResults(sessions);
+    const titleLine = output
+      .split("\n")
+      .find((l) => l.includes("ses_long")) as string;
+    expect(titleLine).toContain("…");
+    expect(titleLine).not.toContain("x".repeat(120));
+    // Truncated title body should be at most 60 chars (59 + ellipsis).
+    expect(titleLine.includes("x".repeat(61))).toBe(false);
+  });
+
+  test("handles missing directory and empty title gracefully", () => {
+    const sessions: Session[] = [
+      mkSession("ses_nodir", "", "", 1000),
+    ];
+
+    const output = formatListResults(sessions);
+    expect(output).toContain("(unknown directory)");
+    expect(output).toContain("(untitled)");
+    expect(output).toContain("ses_nodir");
   });
 });

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,5 +1,70 @@
 import type { SearchMatch } from "./search/keyword";
 import type { FileTraceResult } from "./search/file-trace";
+import type { Session } from "./storage";
+
+const LIST_TITLE_MAX = 60;
+
+function truncateTitle(title: string): string {
+  const clean = (title || "(untitled)").trim() || "(untitled)";
+  if (clean.length <= LIST_TITLE_MAX) return clean;
+  return clean.slice(0, LIST_TITLE_MAX - 1).trimEnd() + "…";
+}
+
+function formatLocalTimestamp(millis: number): string {
+  const d = new Date(millis);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  return `${date} ${time}`;
+}
+
+/**
+ * Render a folder-grouped listing of sessions.
+ * - Folders are sorted by their most-recently-updated session (newest first).
+ * - Sessions within a folder are sorted newest-first.
+ */
+export function formatListResults(sessions: Session[]): string {
+  if (sessions.length === 0) {
+    return "No sessions found.";
+  }
+
+  // Group by directory.
+  const groups = new Map<string, Session[]>();
+  for (const session of sessions) {
+    const dir = session.directory || "(unknown directory)";
+    const existing = groups.get(dir);
+    if (existing) {
+      existing.push(session);
+    } else {
+      groups.set(dir, [session]);
+    }
+  }
+
+  // Sort sessions within each folder newest-first and capture each folder's
+  // most-recent timestamp for folder ordering.
+  const folders = Array.from(groups.entries()).map(([directory, items]) => {
+    items.sort((a, b) => b.time.updated - a.time.updated);
+    const mostRecent = items[0]?.time.updated ?? 0;
+    return { directory, items, mostRecent };
+  });
+
+  // Folders sorted by most-recently-updated session (newest first).
+  folders.sort((a, b) => b.mostRecent - a.mostRecent);
+
+  const lines: string[] = [];
+  for (const folder of folders) {
+    const count = folder.items.length;
+    const plural = count === 1 ? "session" : "sessions";
+    lines.push(`== ${folder.directory}  (${count} ${plural}) ==`);
+    for (const session of folder.items) {
+      const ts = formatLocalTimestamp(session.time.updated);
+      const title = truncateTitle(session.title);
+      lines.push(`  ${ts}    ${title}  ${session.id}`);
+    }
+  }
+
+  return lines.join("\n");
+}
 
 export function formatResults(matches: SearchMatch[]): string {
   if (matches.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,26 @@
 import { tool } from "@opencode-ai/plugin";
-import { getCurrentProjectID } from "./storage-provider";
+import { getCurrentProjectID, listSessions } from "./storage-provider";
 import { searchKeyword } from "./search/keyword";
 import { searchFuzzy } from "./search/fuzzy";
 import { parseDateFilter, filterByDate } from "./search/date-filter";
 import { traceFile } from "./search/file-trace";
-import { formatResults, formatTraceResults } from "./format";
+import { formatResults, formatTraceResults, formatListResults } from "./format";
+import type { Session } from "./storage";
 
 const historySearch = tool({
-  description: `Search through past conversation histories. Use searchAllProjects=true to search ALL projects on this machine. Searches session titles, message content, tool invocations, and file paths. Supports keyword search, regex patterns, fuzzy search (for typos and variations), and date filtering.`,
+  description: `Search through past conversation histories. Use searchAllProjects=true to search ALL projects on this machine. Searches session titles, message content, tool invocations, and file paths. Supports keyword search, regex patterns, fuzzy search (for typos and variations), and date filtering. Use list=true to browse all sessions grouped by folder with per-folder counts (ignores query/filePath).`,
 
   args: {
     query: tool.schema
       .string()
       .optional()
-      .describe("Search query (keyword, regex pattern, or fuzzy search term). Required unless filePath is provided."),
+      .describe("Search query (keyword, regex pattern, or fuzzy search term). Required unless filePath or list is provided."),
+    list: tool.schema
+      .boolean()
+      .optional()
+      .describe(
+        "Set to true to list ALL sessions grouped by folder with per-folder counts, newest-first. Ignores query, filePath, mode, regex, fuzzy, and role. Respects searchAllProjects, date, and limit. Use when the user wants an overview of their sessions, e.g. 'list my sessions' or 'show all my conversations by folder'.",
+      ),
     filePath: tool.schema
       .string()
       .optional()
@@ -65,11 +72,36 @@ const historySearch = tool({
   },
 
   async execute(args) {
-    if (!args.query && !args.filePath) {
-      throw new Error("Either 'query' or 'filePath' must be provided.");
+    if (!args.list && !args.query && !args.filePath) {
+      throw new Error("Either 'query', 'filePath', or 'list' must be provided.");
     }
 
     const projectID = args.searchAllProjects ? null : await getCurrentProjectID();
+
+    // List mode: ignore query/filePath/fuzzy/regex and return a folder-grouped
+    // overview of sessions. Honors searchAllProjects, date, and limit.
+    if (args.list) {
+      const sessions: Session[] = [];
+      for await (const session of listSessions(projectID)) {
+        sessions.push(session);
+      }
+
+      let filtered = sessions;
+      if (args.date) {
+        const dateRange = parseDateFilter(args.date);
+        filtered = filterByDate(
+          sessions.map((s) => ({ ...s, timestamp: s.time.updated })),
+          dateRange,
+        );
+      }
+
+      // Newest-first, then cap by limit (default 50) to match search behaviour.
+      filtered.sort((a, b) => b.time.updated - a.time.updated);
+      const limit = args.limit ?? 50;
+      const capped = filtered.slice(0, limit);
+
+      return formatListResults(capped);
+    }
 
     if (args.filePath) {
       let matches = await traceFile(projectID, args.filePath, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const historySearch = tool({
       .boolean()
       .optional()
       .describe(
-        "Set to true to list ALL sessions grouped by folder with per-folder counts, newest-first. Ignores query, filePath, mode, regex, fuzzy, and role. Respects searchAllProjects, date, and limit. Use when the user wants an overview of their sessions, e.g. 'list my sessions' or 'show all my conversations by folder'.",
+        "Set to true to list sessions grouped by folder with per-folder counts, newest-first. Ignores query, filePath, mode, regex, fuzzy, and role. Respects searchAllProjects, date, and limit (default: 50). Counts reflect the returned (possibly limited) sessions.",
       ),
     filePath: tool.schema
       .string()


### PR DESCRIPTION
Adds a new `list` boolean parameter (default false) that lists all sessions grouped by folder with per-folder counts, newest sessions first. When `list=true`, the tool ignores query/filePath/fuzzy/regex and returns a folder-grouped overview.

### Features
- Sessions grouped by directory, with per-folder counts: `== /path  (N sessions) ==`
- Folders sorted by most-recently-updated session (newest first)
- Sessions sorted newest-first within each folder
- Shows timestamp (local time), title (truncated to ~60 chars), and session ID
- Respects `searchAllProjects`, `date`, and `limit` params
- Zero results handled gracefully with `No sessions found.`

### Changes
- **src/format.ts** — added `formatListResults()` that groups sessions by directory and formats the listing
- **src/format.test.ts** — added 6 tests covering grouping, ordering, truncation, and edge cases
- **src/index.ts** — added `list` boolean arg, early-return block in `execute()`, relaxed query/filePath validation for list mode
- **install.ts** — added `list` param to `TOOL_DESCRIPTION` and usage examples